### PR TITLE
tendl and fendl download scripts added

### DIFF
--- a/convert_fendl.py
+++ b/convert_fendl.py
@@ -82,16 +82,12 @@ block_size = 16384
 # ==============================================================================
 # DOWNLOAD FILES FROM IAEA SITE
 
-# The fendl website requires the web browser to be mocked
-ssl._create_default_https_context = ssl._create_unverified_context
-user_agent = 'Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.9.0.7) Gecko/2009021910 Firefox/3.0.7'
-headers = {'User-Agent': user_agent, }
-
 files_complete = []
 for f in release_details[args.release]['files']:
     # Establish connection to URL
     url = release_details[args.release]['base_url'] + f
-    req = urlopen(Request(url, None, headers))
+    # req = urlopen(Request(url, None, headers))
+    req = urlopen(url, context=ssl._create_unverified_context())
 
     # Get file size from header
     if sys.version_info[0] < 3:

--- a/convert_fendl.py
+++ b/convert_fendl.py
@@ -7,6 +7,7 @@ import tarfile
 import zipfile
 import glob
 import argparse
+import ssl
 from string import digits
 from urllib.request import urlopen, Request
 
@@ -33,7 +34,7 @@ parser.add_argument('-b', '--batch', action='store_true',
 parser.add_argument('-d', '--destination', default=None,
                     help='Directory to create new library in')
 parser.add_argument('--libver', choices=['earliest', 'latest'],
-                    default='latest', help="Output HDF5 versioning. Use "
+                    default='earliest', help="Output HDF5 versioning. Use "
                     "'earliest' for backwards compatibility or 'latest' for "
                     "performance")
 parser.add_argument('-r', '--release', choices=['3.1a', '3.1d'],
@@ -81,6 +82,7 @@ block_size = 16384
 # DOWNLOAD FILES FROM IAEA SITE
 
 # The fendl website requires the web browser to be mocked
+ssl._create_default_https_context = ssl._create_unverified_context
 user_agent = 'Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.9.0.7) Gecko/2009021910 Firefox/3.0.7'
 headers = {'User-Agent': user_agent, }
 

--- a/convert_fendl.py
+++ b/convert_fendl.py
@@ -86,7 +86,6 @@ files_complete = []
 for f in release_details[args.release]['files']:
     # Establish connection to URL
     url = release_details[args.release]['base_url'] + f
-    # req = urlopen(Request(url, None, headers))
     req = urlopen(url, context=ssl._create_unverified_context())
 
     # Get file size from header

--- a/convert_fendl.py
+++ b/convert_fendl.py
@@ -8,6 +8,7 @@ import zipfile
 import glob
 import argparse
 import ssl
+import subprocess
 from string import digits
 from urllib.request import urlopen, Request
 
@@ -134,7 +135,7 @@ for f in release_details[args.release]['files']:
     # unfortunatly which is incompatible with the standard python zipfile library
     # therefore the following system command is used
 
-    os.system('unzip -o ' + f + ' -d '+ ace_files_dir) 
+    subprocess.call(['unzip', '-o', f, '-d', ace_files_dir])
 
 
 # # ==============================================================================

--- a/convert_fendl.py
+++ b/convert_fendl.py
@@ -13,6 +13,7 @@ from string import digits
 from urllib.request import urlopen, Request
 
 import openmc.data
+from openmc._utils import download
 
 
 description = """
@@ -86,38 +87,10 @@ files_complete = []
 for f in release_details[args.release]['files']:
     # Establish connection to URL
     url = release_details[args.release]['base_url'] + f
-    req = urlopen(url, context=ssl._create_unverified_context())
+    downloaded_file = download(url, context=ssl._create_unverified_context())
+    files_complete.append(downloaded_file)
 
-    # Get file size from header
-    if sys.version_info[0] < 3:
-        file_size = int(req.info().getheaders('Content-Length')[0])
-    else:
-        file_size = req.length
-    downloaded = 0
-
-    # Check if file already downloaded
-    if os.path.exists(f):
-        if os.path.getsize(f) == file_size:
-            print('Skipping {}, already downloaded'.format(f))
-            files_complete.append(f)
-            continue
-        else:
-            overwrite = input('Overwrite {}? ([y]/n) '.format(f))
-            if overwrite.lower().startswith('n'):
-                continue
-
-    # Copy file to disk
-    print('Downloading {}... '.format(f), end='')
-    with open(f, 'wb') as fh:
-        while True:
-            chunk = req.read(block_size)
-            if not chunk: break
-            fh.write(chunk)
-            downloaded += len(chunk)
-            status = '{:10}  [{:3.2f}%]'.format(downloaded, downloaded * 100. / file_size)
-            print(status + chr(8)*len(status), end='')
-        print('')
-        files_complete.append(f)
+print('files_complete', files_complete)
 
 # ==============================================================================
 # EXTRACT FILES FROM TGZ

--- a/convert_fendl.py
+++ b/convert_fendl.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+
+import os
+from collections import defaultdict
+import sys
+import tarfile
+import zipfile
+import glob
+import argparse
+from string import digits
+from urllib.request import urlopen, Request
+
+import openmc.data
+
+
+description = """
+Download FENDL 3.1d or FENDL 3.1c ACE data from the IAEA and convert it to a HDF5 library for 
+use with OpenMC.
+
+"""
+
+
+class CustomFormatter(argparse.ArgumentDefaultsHelpFormatter,
+                      argparse.RawDescriptionHelpFormatter):
+    pass
+
+parser = argparse.ArgumentParser(
+    description=description,
+    formatter_class=CustomFormatter
+)
+parser.add_argument('-b', '--batch', action='store_true',
+                    help='supresses standard in')
+parser.add_argument('-d', '--destination', default=None,
+                    help='Directory to create new library in')
+parser.add_argument('--libver', choices=['earliest', 'latest'],
+                    default='latest', help="Output HDF5 versioning. Use "
+                    "'earliest' for backwards compatibility or 'latest' for "
+                    "performance")
+parser.add_argument('-r', '--release', choices=['3.1a', '3.1d'],
+                    default='3.1d', help="The nuclear data library release version. "
+                    "The currently supported options are 3.1a and 3.1d")
+args = parser.parse_args()
+
+# this could be added as an argument to allow different libraries to be downloaded
+library = 'fendl'
+ace_files_dir = '-'.join([library, args.release, 'ace'])
+# the destination is decided after the release is know to avoid putting the release in a folder with a misleading name
+if args.destination == None:
+    args.destination = '-'.join([library, args.release, 'hdf5'])
+
+# This dictionary contains all the unique information about each release. This can be exstened to accommodated new releases
+release_details = {'3.1a': {'base_url': 'https://www-nds.iaea.org/fendl31/data/neutron/',
+                            'files': ['fendl31a-neutron-ace.zip'],
+                            'neutron_files': os.path.join(ace_files_dir, '*'),
+                            'compressed_file_size': '0.4 GB',
+                            'uncompressed_file_size': '3 GB'
+                            },
+                   '3.1d': {'base_url': 'https://www-nds.iaea.org/fendl/data/neutron/',
+                            'files': ['fendl31d-neutron-ace.zip'],
+                            'neutron_files': os.path.join(ace_files_dir, 'fendl31d_ACE', '*'),
+                            'compressed_file_size': '0.5 GB',
+                            'uncompressed_file_size': '3 GB'
+                            }
+                   }
+
+download_warning = """
+WARNING: This script will download {} of data. 
+Extracting and processing the data requires {} of additional free disk space.
+
+Are you sure you want to continue? ([y]/n)
+""".format(release_details[args.release]['compressed_file_size'],
+           release_details[args.release]['uncompressed_file_size'])
+
+response = input(download_warning) if not args.batch else 'y'
+if response.lower().startswith('n'):
+    sys.exit()
+
+block_size = 16384
+
+# ==============================================================================
+# DOWNLOAD FILES FROM IAEA SITE
+
+# The fendl website requires the web browser to be mocked
+user_agent = 'Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.9.0.7) Gecko/2009021910 Firefox/3.0.7'
+headers = {'User-Agent': user_agent, }
+
+files_complete = []
+for f in release_details[args.release]['files']:
+    # Establish connection to URL
+    url = release_details[args.release]['base_url'] + f
+    req = urlopen(Request(url, None, headers))
+
+    # Get file size from header
+    if sys.version_info[0] < 3:
+        file_size = int(req.info().getheaders('Content-Length')[0])
+    else:
+        file_size = req.length
+    downloaded = 0
+
+    # Check if file already downloaded
+    if os.path.exists(f):
+        if os.path.getsize(f) == file_size:
+            print('Skipping {}, already downloaded'.format(f))
+            files_complete.append(f)
+            continue
+        else:
+            overwrite = input('Overwrite {}? ([y]/n) '.format(f))
+            if overwrite.lower().startswith('n'):
+                continue
+
+    # Copy file to disk
+    print('Downloading {}... '.format(f), end='')
+    with open(f, 'wb') as fh:
+        while True:
+            chunk = req.read(block_size)
+            if not chunk: break
+            fh.write(chunk)
+            downloaded += len(chunk)
+            status = '{:10}  [{:3.2f}%]'.format(downloaded, downloaded * 100. / file_size)
+            print(status + chr(8)*len(status), end='')
+        print('')
+        files_complete.append(f)
+
+# ==============================================================================
+# EXTRACT FILES FROM TGZ
+
+for f in release_details[args.release]['files']:
+    if f not in files_complete:
+        continue
+
+    # Extract files, the fendl release was compressed using type 9 zip format
+    # unfortunatly which is incompatible with the standard python zipfile library
+    # therefore the following system command is used
+
+    os.system('unzip -o ' + f + ' -d '+ ace_files_dir) 
+
+
+# # ==============================================================================
+# # GENERATE HDF5 LIBRARY -- NEUTRON FILES
+
+# Get a list of all ACE files, excluding files ending with _ which are old incorrect files kept in the release for backwards compatability
+neutron_files = [f for f in glob.glob(release_details[args.release]['neutron_files']) if not f.endswith('_') and not f.endswith('.xsd')]
+
+# Create output directory if it doesn't exist
+if not os.path.isdir(args.destination):
+    os.mkdir(args.destination)
+
+library = openmc.data.DataLibrary()
+
+for filename in sorted(neutron_files):
+    
+    print('Converting: ' + filename)
+    data = openmc.data.IncidentNeutron.from_ace(filename)
+
+    # Export HDF5 file
+    h5_file = os.path.join(args.destination, data.name + '.h5')
+    print('Writing {}...'.format(h5_file))
+    data.export_to_hdf5(h5_file, 'w', libver=args.libver)
+
+    # Register with library
+    library.register_file(h5_file)
+
+# Write cross_sections.xml
+libpath = os.path.join(args.destination, 'cross_sections.xml')
+library.export_to_xml(libpath)

--- a/convert_fendl.py
+++ b/convert_fendl.py
@@ -44,11 +44,11 @@ parser.add_argument('-r', '--release', choices=['3.1a', '3.1d'],
 args = parser.parse_args()
 
 # this could be added as an argument to allow different libraries to be downloaded
-library = 'fendl'
-ace_files_dir = '-'.join([library, args.release, 'ace'])
+library_name = 'fendl'
+ace_files_dir = '-'.join([library_name, args.release, 'ace'])
 # the destination is decided after the release is know to avoid putting the release in a folder with a misleading name
 if args.destination == None:
-    args.destination = '-'.join([library, args.release, 'hdf5'])
+    args.destination = '-'.join([library_name, args.release, 'hdf5'])
 
 # This dictionary contains all the unique information about each release. This can be exstened to accommodated new releases
 release_details = {'3.1a': {'base_url': 'https://www-nds.iaea.org/fendl31/data/neutron/',

--- a/convert_tendl.py
+++ b/convert_tendl.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+
+import os
+from collections import defaultdict
+import sys
+import tarfile
+import zipfile
+import glob
+import argparse
+from string import digits
+from urllib.request import urlopen
+
+import openmc.data
+
+
+description = """
+Download TENDL 2017 or TENDL 2015 ACE data from PSI and convert it to a HDF5 library for 
+use with OpenMC.
+
+"""
+
+
+
+class CustomFormatter(argparse.ArgumentDefaultsHelpFormatter,
+                      argparse.RawDescriptionHelpFormatter):
+    pass
+
+parser = argparse.ArgumentParser(
+    description=description,
+    formatter_class=CustomFormatter
+)
+parser.add_argument('-b', '--batch', action='store_true',
+                    help='supresses standard in')
+parser.add_argument('-d', '--destination', default=None,
+                    help='Directory to create new library in')
+parser.add_argument('--libver', choices=['earliest', 'latest'],
+                    default='latest', help="Output HDF5 versioning. Use "
+                    "'earliest' for backwards compatibility or 'latest' for "
+                    "performance")
+parser.add_argument('-r', '--release', choices=['2015', '2017'],
+                    default='2017', help="The nuclear data library release version. "
+                    "The currently supported options are 2015 and 2017")
+args = parser.parse_args()
+
+
+
+library = 'tendl' #this could be added as an argument to allow different libraries to be downloaded 
+ace_files_dir = '-'.join([library,args.release,'ace'])
+# the destination is decided after the release is know to avoid putting the release in a folder with a misleading name
+if args.destination == None:
+    args.destination = '-'.join([library, args.release, 'hdf5'])
+
+# This dictionary contains all the unique information about each release. This can be exstened to accommodated new releases
+release_details = {'2015': {'base_url': 'https://tendl.web.psi.ch/tendl_2015//tar_files/',
+                            'files': ['ACE-n.tgz'],
+                            'neutron_files': os.path.join(ace_files_dir, 'neutron_file', '*', '*', 'lib', 'endf', '*-n.ace'),
+                            'metastables': os.path.join(ace_files_dir, 'neutron_file', '*', '*', 'lib', 'endf', '*m-n.ace'),
+                            'compressed_file_size': '5.1 GB',
+                            'uncompressed_file_size': '40 GB'
+                            },
+                   '2017': {'base_url': 'https://tendl.web.psi.ch/tendl_2017/tar_files/',
+                            'files': ['tendl17c.tar.bz2'],
+                            'neutron_files': os.path.join(ace_files_dir, 'ace-17', '*'),
+                            'metastables': os.path.join(ace_files_dir, 'ace-17', '*m'),
+                            'compressed_file_size': '2.1 GB',
+                            'uncompressed_file_size': '14 GB'
+                           }
+                  }
+
+download_warning = """
+WARNING: This script will download {} of data. 
+Extracting and processing the data requires {} of additional free disk space.
+
+Are you sure you want to continue? ([y]/n)
+""".format(release_details[args.release]['compressed_file_size'],
+           release_details[args.release]['uncompressed_file_size'])
+
+response = input(download_warning) if not args.batch else 'y'
+if response.lower().startswith('n'):
+    sys.exit()
+
+block_size = 16384
+
+# ==============================================================================
+# DOWNLOAD FILES FROM WEBSITE
+
+files_complete = []
+for f in release_details[args.release]['files']:
+    # Establish connection to URL
+    url = release_details[args.release]['base_url'] + f
+    req = urlopen(url)
+
+    # Get file size from header
+    if sys.version_info[0] < 3:
+        file_size = int(req.info().getheaders('Content-Length')[0])
+    else:
+        file_size = req.length
+    downloaded = 0
+
+    # Check if file already downloaded
+    if os.path.exists(f):
+        if os.path.getsize(f) == file_size:
+            print('Skipping {}, already downloaded'.format(f))
+            files_complete.append(f)
+            continue
+        else:
+            overwrite = input('Overwrite {}? ([y]/n) '.format(f))
+            if overwrite.lower().startswith('n'):
+                continue
+
+    # Copy file to disk
+    print('Downloading {}... '.format(f), end='')
+    with open(f, 'wb') as fh:
+        while True:
+            chunk = req.read(block_size)
+            if not chunk: break
+            fh.write(chunk)
+            downloaded += len(chunk)
+            status = '{:10}  [{:3.2f}%]'.format(downloaded, downloaded * 100. / file_size)
+            print(status + chr(8)*len(status), end='')
+        print('')
+        files_complete.append(f)
+
+# ==============================================================================
+# EXTRACT FILES FROM TGZ
+
+for f in release_details[args.release]['files']:
+    if f not in files_complete:
+        continue
+
+    # Extract files
+
+    suffix = ''
+    with tarfile.open(f, 'r') as tgz:
+        print('Extracting {0}...'.format(f))
+        tgz.extractall(path=os.path.join(ace_files_dir, suffix))
+
+
+# ==============================================================================
+# CHANGE ZAID FOR METASTABLES
+
+metastables = glob.glob(release_details[args.release]['metastables'])
+for path in metastables:
+    print('    Fixing {} (ensure metastable)...'.format(path))
+    text = open(path, 'r').read()
+    mass_first_digit = int(text[3])
+    if mass_first_digit <= 2:
+        text = text[:3] + str(mass_first_digit + 4) + text[4:]
+        open(path, 'w').write(text)
+
+
+
+# ==============================================================================
+# GENERATE HDF5 LIBRARY -- NEUTRON FILES
+
+# Get a list of all ACE files
+neutron_files = glob.glob(release_details[args.release]['neutron_files'])
+
+# Create output directory if it doesn't exist
+if not os.path.isdir(args.destination):
+    os.mkdir(args.destination)
+
+library = openmc.data.DataLibrary()
+
+for filename in sorted(neutron_files):
+
+    # this is a fix for the TENDL-2017 release where the B10 ACE file which has an error on one of the values
+    if library == 'tendl' and args.release == '2017' and os.path.basename(filename) == 'B010':
+        text = open(filename, 'r').read()
+        if text[423:428] == '86843':
+            print('Manual fix for incorrect value in ACE file') # see OpenMC user group issue for more details
+            text = ''.join(text[:423])+'86896'+''.join(text[428:])
+            open(filename, 'w').write(text)
+    
+    print('Converting: ' + filename)
+    data = openmc.data.IncidentNeutron.from_ace(filename)
+
+    # Export HDF5 file
+    h5_file = os.path.join(args.destination, data.name + '.h5')
+    print('Writing {}...'.format(h5_file))
+    data.export_to_hdf5(h5_file, 'w', libver=args.libver)
+
+    # Register with library
+    library.register_file(h5_file)
+
+# Write cross_sections.xml
+libpath = os.path.join(args.destination, 'cross_sections.xml')
+library.export_to_xml(libpath)

--- a/convert_tendl.py
+++ b/convert_tendl.py
@@ -137,7 +137,6 @@ library = openmc.data.DataLibrary()
 for filename in sorted(neutron_files):
 
     # this is a fix for the TENDL-2017 release where the B10 ACE file which has an error on one of the values
-    print('info', library_name, args.release, os.path.basename(filename))
     if library_name == 'tendl' and args.release == '2017' and os.path.basename(filename) == 'B010':
         text = open(filename, 'r').read()
         if text[423:428] == '86843':


### PR DESCRIPTION
Hi all,

Here is a pull request for some scripts that ease the downloading of FENDL and TENDL nuclear data libraries for your consideration.

The scripts are based on the existing OpenMC scripts for downloading JEFF and NNDC data. These two evaluations are of particular interest for fusion simulations as the ITER reactor requests FENDL data is used and the transmutation we expect in fusion reactors requires a library like TENDL with lots of isotopes when simulating burn-up.

Eventually I would like to add options for different releases, file formats (ENDF or ACE) and further nuclear data libraries such as CENDL and JENDL.