### PR TITLE
Additon of CENDL nuclear data download script

### DIFF
--- a/download_all.sh
+++ b/download_all.sh
@@ -1,6 +1,0 @@
-python3 data/convert_fendl.py
-python3 data/convert_jeff32.py
-python3 data/convert_nndc71.py
-python3 data/convert_tendl.py
-python3 data/generate_endf71.py
-python3 data/generate_jendl.py

--- a/generate_cendl.py
+++ b/generate_cendl.py
@@ -98,7 +98,7 @@ for f in release_details[args.release]['files']:
 # ==============================================================================
 # GENERATE HDF5 LIBRARY -- NEUTRON FILES
 
-# Get a list of all ACE files
+# Get a list of all ENDF files
 neutron_files = glob.glob(release_details[args.release]['neutron_files'])
 
 # Create output directory if it doesn't exist
@@ -112,14 +112,12 @@ for filename in sorted(neutron_files):
     # this is a fix for the CENDL 3.1 release where the 22-Ti-047.C31 and 5-B-010.C31 files contain non-ASCII characters
     if library_name == 'cendl' and args.release == '3.1' and os.path.basename(filename) in  ['22-Ti-047.C31','5-B-010.C31']:
         print('Manual fix for incorrect value in ENDF file')
-        text = open(filename, 'rb').read().decode('utf-8','ignore')
-        text_lines=text.split('\r\n')
+        text = open(filename, 'rb').read().decode('utf-8','ignore').split('\r\n')
         if os.path.basename(filename) == '22-Ti-047.C31':
-            text_lines[205] = ' 8) YUAN Junqian,WANG Yongchang,etc.               ,16,(1),57,92012228 1451  205'
+            text[205] = ' 8) YUAN Junqian,WANG Yongchang,etc.               ,16,(1),57,92012228 1451  205'
         if os.path.basename(filename) == '5-B-010.C31':
-            text_lines[203] = '21)   Day R.B. and Walt M.  Phys.rev.117,1330 (1960)               525 1451  203'
-        #file_string = b"".join(text).decode("utf-8") 
-        open(filename, 'w').write('\r\n'.join(text_lines))
+            text[203] = '21)   Day R.B. and Walt M.  Phys.rev.117,1330 (1960)               525 1451  203'
+        open(filename, 'w').write('\r\n'.join(text))
 
     print('Converting: ' + filename)
     data = openmc.data.IncidentNeutron.from_njoy(filename)

--- a/generate_cendl.py
+++ b/generate_cendl.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+
+import argparse
+import glob
+import os
+import sys
+import zipfile
+
+import openmc.data
+from openmc._utils import download
+
+description = """
+Download CENDL 3.1 data from OECD NEA and convert it to a HDF5 library for
+use with OpenMC.
+
+"""
+
+
+class CustomFormatter(argparse.ArgumentDefaultsHelpFormatter,
+                      argparse.RawDescriptionHelpFormatter):
+    pass
+
+
+parser = argparse.ArgumentParser(
+    description=description,
+    formatter_class=CustomFormatter
+)
+parser.add_argument('-b', '--batch', action='store_true',
+                    help='supresses standard in')
+parser.add_argument('-d', '--destination', default=None,
+                    help='Directory to create new library in')
+parser.add_argument('--libver', choices=['earliest', 'latest'],
+                    default='latest', help="Output HDF5 versioning. Use "
+                    "'earliest' for backwards compatibility or 'latest' for "
+                    "performance")
+parser.add_argument('-r', '--release', choices=['3.1'],
+                    default='3.1', help="The nuclear data library release version. "
+                    "The only option currently supported is 3.1")
+args = parser.parse_args()
+
+
+
+library_name = 'cendl' #this could be added as an argument to allow different libraries to be downloaded
+endf_files_dir = '-'.join([library_name, args.release, 'endf'])
+# the destination is decided after the release is known to avoid putting the release in a folder with a misleading name
+if args.destination is None:
+    args.destination = '-'.join([library_name, args.release, 'hdf5'])
+
+# This dictionary contains all the unique information about each release. This can be exstened to accommodated new releases
+release_details = {
+    '3.1': {
+        'base_url': 'https://www.oecd-nea.org/dbforms/data/eva/evatapes/cendl_31/',
+        'files': ['CENDL-31.zip'],
+        'neutron_files': os.path.join(endf_files_dir, '*.C31'),
+        'metastables': os.path.join(endf_files_dir, '*m.C31'),
+        'compressed_file_size': '0.03 GB',
+        'uncompressed_file_size': '0.4 GB'
+    }
+}
+
+download_warning = """
+WARNING: This script will download {} of data.
+Extracting and processing the data requires {} of additional free disk space.
+
+Are you sure you want to continue? ([y]/n)
+""".format(release_details[args.release]['compressed_file_size'],
+           release_details[args.release]['uncompressed_file_size'])
+
+response = input(download_warning) if not args.batch else 'y'
+if response.lower().startswith('n'):
+    sys.exit()
+
+# ==============================================================================
+# DOWNLOAD FILES FROM WEBSITE
+
+files_complete = []
+for f in release_details[args.release]['files']:
+    # Establish connection to URL
+    url = release_details[args.release]['base_url'] + f
+    downloaded_file = download(url)
+    files_complete.append(downloaded_file)
+
+# ==============================================================================
+# EXTRACT FILES FROM ZIP
+
+for f in release_details[args.release]['files']:
+    if f not in files_complete:
+        continue
+
+    # Extract files
+
+    suffix = ''
+    with zipfile.ZipFile(f) as zf:
+        print('Extracting {0}...'.format(f))
+        zf.extractall(path=os.path.join(endf_files_dir, suffix))
+
+
+# ==============================================================================
+# GENERATE HDF5 LIBRARY -- NEUTRON FILES
+
+# Get a list of all ACE files
+neutron_files = glob.glob(release_details[args.release]['neutron_files'])
+
+# Create output directory if it doesn't exist
+if not os.path.isdir(args.destination):
+    os.mkdir(args.destination)
+
+library = openmc.data.DataLibrary()
+
+for filename in sorted(neutron_files):
+
+    # this is a fix for the CENDL 3.1 release where the 22-Ti-047.C31 and 5-B-010.C31 files contain non-ASCII characters
+    if library_name == 'cendl' and args.release == '3.1' and os.path.basename(filename) in  ['22-Ti-047.C31','5-B-010.C31']:
+        print('Manual fix for incorrect value in ENDF file')
+        text = open(filename, 'rb').read().decode('utf-8','ignore')
+        text_lines=text.split('\r\n')
+        if os.path.basename(filename) == '22-Ti-047.C31':
+            text_lines[205] = ' 8) YUAN Junqian,WANG Yongchang,etc.               ,16,(1),57,92012228 1451  205'
+        if os.path.basename(filename) == '5-B-010.C31':
+            text_lines[203] = '21)   Day R.B. and Walt M.  Phys.rev.117,1330 (1960)               525 1451  203'
+        #file_string = b"".join(text).decode("utf-8") 
+        open(filename, 'w').write('\r\n'.join(text_lines))
+
+    print('Converting: ' + filename)
+    data = openmc.data.IncidentNeutron.from_njoy(filename)
+
+    # Export HDF5 file
+    h5_file = os.path.join(args.destination, data.name + '.h5')
+    print('Writing {}...'.format(h5_file))
+    data.export_to_hdf5(h5_file, 'w', libver=args.libver)
+
+    # Register with library
+    library.register_file(h5_file)
+
+# Write cross_sections.xml
+libpath = os.path.join(args.destination, 'cross_sections.xml')
+library.export_to_xml(libpath)


### PR DESCRIPTION
Continuing the theme of including more nuclear data libraries.

This PR contains a new `generate_cendl.py` script that downloads and uses the openmc njoy functions to generate h5 files from the cendl endf files and makes it easy to use CENDL 3.1 with OpenMC.

There is one part of the script which fixes a couple of endf files as the CENDL 3.1 release contains a couple of files with non ASCII characters, as discussed in OpenMC issue #1177 

Also I spotted that the repo contains a `download_all.sh` script that was accidentally introduced last time, so this has been deleted. Sorry about that

