### PR TITLE
Use as_browser=True in convert_fendl.py

### DIFF
--- a/convert_fendl.py
+++ b/convert_fendl.py
@@ -84,7 +84,8 @@ files_complete = []
 for f in release_details[args.release]['files']:
     # Establish connection to URL
     url = release_details[args.release]['base_url'] + f
-    downloaded_file = download(url, context=ssl._create_unverified_context())
+    downloaded_file = download(url, as_browser=True,
+                               context=ssl._create_unverified_context())
     files_complete.append(downloaded_file)
 
 # ==============================================================================


### PR DESCRIPTION
This PR fixes the convert_fendl.py script and relies on https://github.com/openmc-dev/openmc/pull/1277.