### PR TITLE
Jeff temperature control

### DIFF
--- a/convert_jeff32.py
+++ b/convert_jeff32.py
@@ -73,7 +73,7 @@ release_details = {
     '3.3':{
         'base_url': 'https://www.oecd-nea.org/dbdata/jeff/jeff33/downloads/',
         'files': ['JEFF33-n.tgz',
-                'JEFF33-n_tsl-ace.tgz'],
+                  'JEFF33-n_tsl-ace.tgz'],
         # 'neutron_files': os.path.join('jeff-3.3', '*', '*.ACE'),
         # 'metastables': os.path.join('jeff-3.3', '**', '*M.ACE'),
         # 'sab_files': os.path.join('jeff-3.3', 'ANNEX_6_3_STLs', '*', '*.ace'),

--- a/convert_jeff32.py
+++ b/convert_jeff32.py
@@ -36,33 +36,50 @@ parser.add_argument('--libver', choices=['earliest', 'latest'],
                     default='latest', help="Output HDF5 versioning. Use "
                     "'earliest' for backwards compatibility or 'latest' for "
                     "performance")
-parser.add_argument('-r', '--release', choices=['3.2'],
+parser.add_argument('-r', '--release', choices=['3.2', '3.3'],
                     default='3.2', help="The nuclear data library release version. "
-                    "The currently supported option is 3.2")                    
+                    "The currently supported options are 3.2 and 3.3")                    
 args = parser.parse_args()
+
+library_name = 'jeff'
+ace_files_dir = '-'.join([library_name, args.release, 'ace'])
+# the destination is decided after the release is know to avoid putting the release in a folder with a misleading name
+if args.destination is None:
+    args.destination = '-'.join([library_name, args.release, 'hdf5'])
 
 # This dictionary contains all the unique information about each release. This can be exstened to accommodated new releases
 release_details = {
     '3.2':{
         'base_url': 'https://www.oecd-nea.org/dbforms/data/eva/evatapes/jeff_32/Processed/',
         'files': ['JEFF32-ACE-293K.tar.gz',
-                'JEFF32-ACE-400K.tar.gz',
-                'JEFF32-ACE-500K.tar.gz',
-                'JEFF32-ACE-600K.tar.gz',
-                'JEFF32-ACE-700K.tar.gz',
-                'JEFF32-ACE-800K.zip',
-                'JEFF32-ACE-900K.tar.gz',
-                'JEFF32-ACE-1000K.tar.gz',
-                'JEFF32-ACE-1200K.tar.gz',
-                'JEFF32-ACE-1500K.tar.gz',
-                'JEFF32-ACE-1800K.tar.gz',
-                'TSLs.tar.gz'],
+                  'JEFF32-ACE-400K.tar.gz',
+                  'JEFF32-ACE-500K.tar.gz',
+                  'JEFF32-ACE-600K.tar.gz',
+                  'JEFF32-ACE-700K.tar.gz',
+                  'JEFF32-ACE-800K.zip',
+                  'JEFF32-ACE-900K.tar.gz',
+                  'JEFF32-ACE-1000K.tar.gz',
+                  'JEFF32-ACE-1200K.tar.gz',
+                  'JEFF32-ACE-1500K.tar.gz',
+                  'JEFF32-ACE-1800K.tar.gz',
+                  'TSLs.tar.gz'],
         'neutron_files': os.path.join('jeff-3.2', '*', '*.ACE'),
         'metastables': os.path.join('jeff-3.2', '**', '*M.ACE'),
         'sab_files': os.path.join('jeff-3.2', 'ANNEX_6_3_STLs', '*', '*.ace'),
         'redundant': os.path.join('jeff-3.2', 'ACEs_293K', '*-293.ACE'),
         'compressed_file_size': '9 GB',
         'uncompressed_file_size': '40 GB'
+    },
+    '3.3':{
+        'base_url': 'https://www.oecd-nea.org/dbdata/jeff/jeff33/downloads/',
+        'files': ['JEFF33-n.tgz',
+                'JEFF33-n_tsl-ace.tgz'],
+        # 'neutron_files': os.path.join('jeff-3.3', '*', '*.ACE'),
+        # 'metastables': os.path.join('jeff-3.3', '**', '*M.ACE'),
+        # 'sab_files': os.path.join('jeff-3.3', 'ANNEX_6_3_STLs', '*', '*.ace'),
+        # 'redundant': os.path.join('jeff-3.3', 'ACEs_293K', '*-293.ACE'),
+        'compressed_file_size': '2 GB',
+        'uncompressed_file_size': '? GB'
     }
 }
 
@@ -102,13 +119,13 @@ for f in release_details[args.release]['files']:
     if f.endswith('.zip'):
         with zipfile.ZipFile(f, 'r') as zipf:
             print('Extracting {}...'.format(f))
-            zipf.extractall('jeff-3.2')
+            zipf.extractall(ace_files_dir)
 
     else:
         suffix = 'ACEs_293K' if '293' in f else ''
         with tarfile.open(f, 'r') as tgz:
             print('Extracting {}...'.format(f))
-            tgz.extractall(os.path.join('jeff-3.2', suffix))
+            tgz.extractall(os.path.join(ace_files_dir, suffix))
 
         # Remove thermal scattering tables from 293K data since they are
         # redundant


### PR DESCRIPTION
These changes allow separate temperature files from the JEFF 3.2 library to be downloaded. 

for example the following command will download just 400K and 500K temperature ace files

`python3 convert_jeff32.py -temperatures 400 500`

Previously the script had to be edited manually when users wanted to download just a subsection of the many temperatures available.

I would have like to add Jeff 3.3 release to the script but it is only available ENDF format from the website so I backtracked on that potential feature for now