### PR TITLE
Jeff32 temperature control

### DIFF
--- a/convert_jeff32.py
+++ b/convert_jeff32.py
@@ -142,7 +142,6 @@ for filename in sorted(neutron_files):
 
 # Sort temperatures from lowest to highest
 for name, filenames in sorted(tables.items()):
-    print(filenames)
     filenames.sort(key=lambda x: int(
         x.split(os.path.sep)[1].split('_')[1][:-1]))
 

--- a/convert_jeff32.py
+++ b/convert_jeff32.py
@@ -47,8 +47,14 @@ parser.add_argument('--libver', choices=['earliest', 'latest'],
                     default='latest', help="Output HDF5 versioning. Use "
                     "'earliest' for backwards compatibility or 'latest' for "
                     "performance")
+parser.add_argument('-r', '--release', choices=['3.2'],
+                    default='3.2', help="The nuclear data library release version. "
+                    "The currently supported options are 3.2")
 parser.set_defaults(download=True, extract=True)
 args = parser.parse_args()
+
+library_name = 'jeff'
+ace_files_dir = '-'.join([library_name, args.release, 'ace'])
 
 print(download_warning)
 
@@ -82,13 +88,13 @@ if args.extract:
         if f.endswith('.zip'):
             with zipfile.ZipFile(f, 'r') as zipf:
                 print('Extracting {}...'.format(f))
-                zipf.extractall('jeff-3.2')
+                zipf.extractall(ace_files_dir)
 
         else:
             suffix = 'ACEs_293K' if '293' in f else ''
             with tarfile.open(f, 'r') as tgz:
                 print('Extracting {}...'.format(f))
-                tgz.extractall(os.path.join('jeff-3.2', suffix))
+                tgz.extractall(os.path.join(ace_files_dir, suffix))
 
             # Remove thermal scattering tables from 293K data since they are
             # redundant

--- a/convert_jeff32.py
+++ b/convert_jeff32.py
@@ -33,7 +33,7 @@ parser = argparse.ArgumentParser(
     description=description,
     formatter_class=CustomFormatter
 )
-parser.add_argument('-d', '--destination', default='jeff32_hdf5',
+parser.add_argument('-d', '--destination', default='jeff-3.2-hdf5',
                     help='Directory to create new library in')
 parser.add_argument('--download', action='store_true',
                     help='Download files from OECD-NEA')

--- a/convert_jeff32.py
+++ b/convert_jeff32.py
@@ -113,7 +113,7 @@ if args.extract:
             # redundant
             if '293' in f:
                 for path in release_details[args.release]['redundant']:
-                    print('removing ', path)
+                    print(f'removing {path}')
                     os.remove(path)
 
 # ==============================================================================

--- a/convert_jeff32.py
+++ b/convert_jeff32.py
@@ -176,7 +176,7 @@ tables = defaultdict(list)
 for filename in sorted(release_details[args.release]['sab_files']):
     dirname, basename = os.path.split(filename)
     name = basename.split('-')[0]
-    tables[name].append(filename.as_posix())
+    tables[name].append(str(filename))
 
 # Sort temperatures from lowest to highest
 for name, filenames in sorted(tables.items()):

--- a/convert_jeff32.py
+++ b/convert_jeff32.py
@@ -138,7 +138,7 @@ neutron_files = release_details[args.release]['neutron_files']
 tables = defaultdict(list)
 for filename in sorted(neutron_files):
     name = filename.stem
-    tables[name].append(filename.as_posix())
+    tables[name].append(str(filename))
 
 # Sort temperatures from lowest to highest
 for name, filenames in sorted(tables.items()):

--- a/convert_jeff32.py
+++ b/convert_jeff32.py
@@ -210,4 +210,4 @@ for name, filenames in sorted(tables.items()):
     library.register_file(h5_file)
 
 # Write cross_sections.xml
-library.export_to_xml(args.destination.joinpath('cross_sections.xml'))
+library.export_to_xml(args.destination / 'cross_sections.xml')

--- a/convert_jeff32.py
+++ b/convert_jeff32.py
@@ -107,7 +107,7 @@ if args.extract:
             suffix = 'ACEs_293K' if '293' in f else ''
             with tarfile.open(f, 'r') as tgz:
                 print('Extracting {}...'.format(f))
-                tgz.extractall(ace_files_dir.joinpath(suffix))
+                tgz.extractall(ace_files_dir / suffix)
 
             # Remove thermal scattering tables from 293K data since they are
             # redundant

--- a/convert_jeff32.py
+++ b/convert_jeff32.py
@@ -64,8 +64,8 @@ if args.destination is None:
 release_details = {
     '3.2':{
         'base_url': 'https://www.oecd-nea.org/dbforms/data/eva/evatapes/jeff_32/Processed/',
-        'files': [f'JEFF32-ACE-{temperature}K.tar.gz' for temperature in args.temperatures]
-                +['TSLs.tar.gz'],
+        'files': [f'JEFF32-ACE-{t}K.zip' if t=='800' else f'JEFF32-ACE-{t}K.tar.gz' for t in args.temperatures] 
+                  +['TSLs.tar.gz'],
         'neutron_files':ace_files_dir.rglob('*.ACE'),
         'metastables': ace_files_dir.rglob('*M.ACE'),
         'sab_files': ace_files_dir.glob('ANNEX_6_3_STLs/*/*.ace'),
@@ -78,17 +78,16 @@ release_details = {
 download_warning = """
 WARNING: This script will download up to {} GB of data. Extracting and
 processing the data may require as much as {} GB of additional free disk
-space. Note that if you don't need all 11 temperatures, you can modify the
-'files' list in the script to download only the data you want.
+space. Note that if you don't need all 11 temperatures, you can used the 
+--temperature argument to download only the temperatures you want.
 """.format(release_details[args.release]['compressed_file_size'],
            release_details[args.release]['uncompressed_file_size'])
-
-print(download_warning)
 
 # ==============================================================================
 # DOWNLOAD FILES FROM OECD SITE
 
 if args.download:
+    print(download_warning)
     for f in release_details[args.release]['files']:
         download(urljoin(release_details[args.release]['base_url'], f))
 

--- a/convert_jeff32.py
+++ b/convert_jeff32.py
@@ -161,7 +161,7 @@ for name, filenames in sorted(tables.items()):
         data.add_temperature_from_ace(filename)
 
     # Export HDF5 file
-    h5_file = args.destination.joinpath(data.name + '.h5')
+    h5_file = args.destination / f'{data.name}.h5'
     print('Writing {}...'.format(h5_file))
     data.export_to_hdf5(h5_file, 'w', libver=args.libver)
 

--- a/convert_jeff32.py
+++ b/convert_jeff32.py
@@ -64,7 +64,7 @@ if args.destination is None:
 release_details = {
     '3.2':{
         'base_url': 'https://www.oecd-nea.org/dbforms/data/eva/evatapes/jeff_32/Processed/',
-        'files':['JEFF32-ACE-'+temperature+'K.tar.gz' for temperature in args.temperatures]
+        'files': [f'JEFF32-ACE-{temperature}K.tar.gz' for temperature in args.temperatures]
                 +['TSLs.tar.gz'],
         'neutron_files':ace_files_dir.rglob('*.ACE'),
         'metastables': ace_files_dir.rglob('*M.ACE'),

--- a/convert_jeff32.py
+++ b/convert_jeff32.py
@@ -202,7 +202,7 @@ for name, filenames in sorted(tables.items()):
         data.add_temperature_from_ace(table)
 
     # Export HDF5 file
-    h5_file = args.destination.joinpath(data.name + '.h5')
+    h5_file = args.destination / f'{data.name}.h5'
     print('Writing {}...'.format(h5_file))
     data.export_to_hdf5(h5_file, 'w', libver=args.libver)
 


### PR DESCRIPTION
These changes allow separate temperature files from the JEFF 3.2 library to be downloaded.

For example the following command will download just 400K and 500K temperature ace files

python3 convert_jeff32.py -temperatures 400 500

Previously the script had to be edited manually when users wanted to download just a subsection of the 11 temperatures available.

I have also move the script from os.path to pathlib which saves a few lines of code in places

I have also done some generalising so that other releases of Jeff could perhaps be added