### PR TITLE
added ssl context to download

### DIFF
--- a/generate_jendl.py
+++ b/generate_jendl.py
@@ -3,6 +3,7 @@
 import argparse
 import glob
 import os
+import ssl
 import sys
 import tarfile
 
@@ -77,7 +78,8 @@ files_complete = []
 for f in release_details[args.release]['files']:
     # Establish connection to URL
     url = release_details[args.release]['base_url'] + f
-    downloaded_file = download(url)
+    downloaded_file = download(url, 
+                               context=ssl._create_unverified_context()))
     files_complete.append(downloaded_file)
 
 # ==============================================================================

--- a/generate_jendl.py
+++ b/generate_jendl.py
@@ -79,7 +79,7 @@ for f in release_details[args.release]['files']:
     # Establish connection to URL
     url = release_details[args.release]['base_url'] + f
     downloaded_file = download(url, 
-                               context=ssl._create_unverified_context()))
+                               context=ssl._create_unverified_context())
     files_complete.append(downloaded_file)
 
 # ==============================================================================


### PR DESCRIPTION
This is a small fix to correct an error that prevents the generate_jendl script downloading data.

`context=ssl._create_unverified_context()` was added to the call for download(url) to avoid the following error.

```
Traceback (most recent call last):
  File "generate_jendl.py", line 81, in <module>
    downloaded_file = download(url)
  File "/home/jshim/openmc/openmc/_utils.py", line 34, in download
    req = urlopen(page, **kwargs)
  File "/usr/lib/python3.6/urllib/request.py", line 223, in urlopen
    return opener.open(url, data, timeout)
  File "/usr/lib/python3.6/urllib/request.py", line 526, in open
    response = self._open(req, data)
  File "/usr/lib/python3.6/urllib/request.py", line 544, in _open
    '_open', req)
  File "/usr/lib/python3.6/urllib/request.py", line 504, in _call_chain
    result = func(*args)
  File "/usr/lib/python3.6/urllib/request.py", line 1361, in https_open
    context=self._context, check_hostname=self._check_hostname)
  File "/usr/lib/python3.6/urllib/request.py", line 1320, in do_open
    raise URLError(err)
urllib.error.URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:847)>

```