### PR TITLE
general update of args, path instead of os.system, using incidentphoton

### DIFF
--- a/convert_nndc71.py
+++ b/convert_nndc71.py
@@ -92,8 +92,8 @@ release_details = {
 
 compressed_file_size, uncompressed_file_size = 0, 0
 for p in ('neutron', 'photon'): 
-    compressed_file_size += release_details['b7.1'][p]['compressed_file_size']
-    uncompressed_file_size += release_details['b7.1'][p]['uncompressed_file_size']
+    compressed_file_size += release_details[args.release][p]['compressed_file_size']
+    uncompressed_file_size += release_details[args.release][p]['uncompressed_file_size']
 
 download_warning = """
 WARNING: This script will download up to {} MB of data. Extracting and
@@ -113,7 +113,6 @@ if args.download:
         for f in release_details[args.release][particle]['compressed_files']:
             # Establish connection to URL
             url = release_details[args.release][particle]['base_url'] + f
-            print(url)
             downloaded_file = download(url)
 
 

--- a/convert_nndc71.py
+++ b/convert_nndc71.py
@@ -22,18 +22,12 @@ from openmc._utils import download
 # Make sure Python version is sufficient
 assert sys.version_info >= (3, 6), "Python 3.6+ is required"
 
-description = """
-Download ENDF/B-VII.1 incident neutron ACE data and incident photon ENDF data
-from NNDC and convert it to an HDF5 library for use with OpenMC. This data is
-used for OpenMC's regression test suite.
-"""
-
 class CustomFormatter(argparse.ArgumentDefaultsHelpFormatter,
                       argparse.RawDescriptionHelpFormatter):
     pass
 
 parser = argparse.ArgumentParser(
-    description=description,
+    description=__doc__,
     formatter_class=CustomFormatter
 )
 

--- a/convert_nndc71.py
+++ b/convert_nndc71.py
@@ -97,7 +97,7 @@ release_details = {
 
 
 compressed_file_size, uncompressed_file_size = 0, 0
-for p in ['neutron','photon']: 
+for p in ('neutron', 'photon'): 
     compressed_file_size += release_details['b7.1'][p]['compressed_file_size']
     uncompressed_file_size += release_details['b7.1'][p]['uncompressed_file_size']
 

--- a/convert_nndc71.py
+++ b/convert_nndc71.py
@@ -213,7 +213,6 @@ for particle in args.particles:
 
 
     elif particle == 'photon':
-        print(particle)
         for photo_file, atom_file in zip(sorted(release_details[release][particle]['photo_file']),
                                          sorted(release_details[release][particle]['atom_file'])):
     

--- a/convert_nndc71.py
+++ b/convert_nndc71.py
@@ -191,10 +191,7 @@ for particle in args.particles:
 
             print('Converting: ' , filename)
             table = openmc.data.ace.get_table(filename)
-            name, xs = table.name.split('.')
-            table.name = '.'.join((name.strip(digits), xs))
             data = openmc.data.ThermalScattering.from_ace(table)
-            
             # Export HDF5 file
             h5_file = args.destination.joinpath(particle, data.name + '.h5')
             data.export_to_hdf5(h5_file, 'w', libver=args.libver)
@@ -234,3 +231,4 @@ for particle in args.particles:
 
 # Write cross_sections.xml
 library.export_to_xml(args.destination / 'cross_sections.xml')
+print('written ',args.destination / 'cross_sections.xml')

--- a/convert_nndc71.py
+++ b/convert_nndc71.py
@@ -71,7 +71,7 @@ release_details = {
             'ace_files': ace_files_dir.rglob('[aA-zZ]*.ace'),
             'sab_files': ace_files_dir.rglob('*.acer'),
             'compressed_file_size': 497,
-            'uncompressed_file_size': 0.1
+            'uncompressed_file_size': 1200
             },
         'photon': 
             {
@@ -82,7 +82,7 @@ release_details = {
             'photo_file': endf_files_dir.joinpath('photoat').rglob('*.endf'),
             'atom_file': endf_files_dir.joinpath('atomic_relax').rglob('*.endf'),
             'compressed_file_size': 9,
-            'uncompressed_file_size': 0.1
+            'uncompressed_file_size': 45
             }
         }
     

--- a/convert_nndc71.py
+++ b/convert_nndc71.py
@@ -45,17 +45,15 @@ parser.add_argument('--libver', choices=['earliest', 'latest'],
                     default='earliest', help="Output HDF5 versioning. Use "
                     "'earliest' for backwards compatibility or 'latest' for "
                     "performance")
-parser.add_argument('-r', '--release', choices=['b7.1'],
-                    default='b7.1', help="The nuclear data library release version. "
-                    "The currently supported options are b7.1")
 parser.add_argument('-p', '--particles', choices=['neutron', 'photon'], nargs='+',
                     default=['neutron', 'photon'], help="Incident particles to include")   
 parser.set_defaults(download=True, extract=True)
 args = parser.parse_args()
 
 library_name = 'nndc'
-ace_files_dir = Path('-'.join([library_name, args.release, 'ace']))
-endf_files_dir = Path('-'.join([library_name, args.release, 'endf']))
+release = 'b7.1'
+ace_files_dir = Path('-'.join([library_name, release, 'ace']))
+endf_files_dir = Path('-'.join([library_name, release, 'endf']))
 
 # This dictionary contains all the unique information about each release. This can be exstened to accommodated new releases
 release_details = {
@@ -92,8 +90,8 @@ release_details = {
 
 compressed_file_size, uncompressed_file_size = 0, 0
 for p in ('neutron', 'photon'): 
-    compressed_file_size += release_details[args.release][p]['compressed_file_size']
-    uncompressed_file_size += release_details[args.release][p]['uncompressed_file_size']
+    compressed_file_size += release_details[release][p]['compressed_file_size']
+    uncompressed_file_size += release_details[release][p]['uncompressed_file_size']
 
 download_warning = """
 WARNING: This script will download up to {} MB of data. Extracting and
@@ -110,9 +108,9 @@ for use with OpenMC. This data is used for OpenMC's regression test suite.
 if args.download:
     for particle in args.particles:
         print(download_warning)
-        for f in release_details[args.release][particle]['compressed_files']:
+        for f in release_details[release][particle]['compressed_files']:
             # Establish connection to URL
-            url = release_details[args.release][particle]['base_url'] + f
+            url = release_details[release][particle]['base_url'] + f
             downloaded_file = download(url)
 
 
@@ -122,9 +120,9 @@ if args.download:
 if args.download:
     print('Verifying MD5 checksums...')
     for particle in args.particles:
-        if 'checksums' in release_details[args.release].keys():
-            for f, checksum in zip(release_details[args.release]['compressed_files'], 
-                                    release_details[args.release]['checksums']):
+        if 'checksums' in release_details[release].keys():
+            for f, checksum in zip(release_details[release]['compressed_files'], 
+                                    release_details[release]['checksums']):
                 downloadsum = hashlib.md5(open(f, 'rb').read()).hexdigest()
                 print(downloadsum,f)
             if downloadsum != checksum:
@@ -140,12 +138,12 @@ if args.download:
 if args.extract:
     for particle in args.particles:
 
-        if release_details[args.release][particle]['file_type'] == 'ace':
+        if release_details[release][particle]['file_type'] == 'ace':
             extraction_dir = ace_files_dir
-        elif release_details[args.release][particle]['file_type'] == 'endf':
+        elif release_details[release][particle]['file_type'] == 'endf':
             extraction_dir = endf_files_dir
 
-        for f in release_details[args.release][particle]['compressed_files']:
+        for f in release_details[release][particle]['compressed_files']:
             # Extract files
 
             if f.endswith('.zip'):
@@ -185,7 +183,7 @@ library = openmc.data.DataLibrary()
 
 for particle in args.particles: 
     if particle == 'neutron':
-        for filename in sorted(release_details[args.release][particle]['ace_files']):
+        for filename in sorted(release_details[release][particle]['ace_files']):
 
             print('Converting: ' , filename)
             data = openmc.data.IncidentNeutron.from_ace(filename)
@@ -200,8 +198,8 @@ for particle in args.particles:
 
     elif particle == 'photon':
         print(particle)
-        for photo_file, atom_file in zip(sorted(release_details[args.release][particle]['photo_file']),
-                                         sorted(release_details[args.release][particle]['atom_file'])):
+        for photo_file, atom_file in zip(sorted(release_details[release][particle]['photo_file']),
+                                         sorted(release_details[release][particle]['atom_file'])):
     
             print('Converting: ' , photo_file, atom_file)
             

--- a/convert_nndc71.py
+++ b/convert_nndc71.py
@@ -178,7 +178,10 @@ if 'neutrons' in args.particles:
 # GENERATE HDF5 LIBRARY
 
 # Create output directory if it doesn't exist
-args.destination.mkdir(parents=True, exist_ok=True)
+for particle in args.particles:
+    particle_destination = args.destination / particle
+    particle_destination.mkdir(parents=True, exist_ok=True)
+
 
 library = openmc.data.DataLibrary()
 
@@ -193,7 +196,7 @@ for particle in args.particles:
             data = openmc.data.ThermalScattering.from_ace(table)
             
             # Export HDF5 file
-            h5_file = args.destination.joinpath(data.name + '.h5')
+            h5_file = args.destination.joinpath(particle, data.name + '.h5')
             data.export_to_hdf5(h5_file, 'w', libver=args.libver)
             
             # Register with library
@@ -205,7 +208,7 @@ for particle in args.particles:
             data = openmc.data.IncidentNeutron.from_ace(filename)
 
             # Export HDF5 file
-            h5_file = args.destination.joinpath(data.name + '.h5')
+            h5_file = args.destination.joinpath(particle, data.name + '.h5')
             data.export_to_hdf5(h5_file, 'w', libver=args.libver)
 
             # Register with library
@@ -222,7 +225,7 @@ for particle in args.particles:
             data = openmc.data.IncidentPhoton.from_endf(photo_file, atom_file)
 
             # Export HDF5 file
-            h5_file = args.destination.joinpath(data.name + '.h5')
+            h5_file = args.destination.joinpath(particle, data.name + '.h5')
             data.export_to_hdf5(h5_file, 'w', libver=args.libver)
 
             # Register with library


### PR DESCRIPTION
This is a first attempt at a general rewrite of the convert_nndc71.py script.

- The script now uses openmc.data.IncidentPhoton instead of running a subprocess call to openmc-ace-to-hdf5 which is a script that is not included in the data repository 

- The script now allows new arguments as first introduced in PR #8 

- The script also has a dictionary structure for the release details. This will allow us to ad future releases of nndc to the same script easily.

- pathlib is now being used instead of os.path

The script is not yet handling the S(a,b) cross sections and I could do with some pointers here and therefore this is a draft PR

Thanks all

