### PR TITLE
Update MCNP data library conversion scripts

### DIFF
--- a/convert_mcnp71.py
+++ b/convert_mcnp71.py
@@ -14,8 +14,9 @@ assert sys.version_info >= (3, 6), "Python 3.6+ is required"
 description = """
 Convert ENDF/B-VII.1 ACE data from the MCNP6 distribution into an HDF5 library
 that can be used by OpenMC. This assumes that you have a directory containing
-subdirectories 'endf71x' and 'ENDF71SaB'. If the 'mcplib84' photoatomic library
-is present in the data directory, it will also be converted.
+subdirectories 'endf71x' and 'ENDF71SaB'. Optionally, if a recent photoatomic
+library (e.g., eprdata14) is available, it can also be converted using the
+--photon argument.
 
 """
 
@@ -35,17 +36,43 @@ parser.add_argument('--libver', choices=['earliest', 'latest'],
                     default='earliest', help="Output HDF5 versioning. Use "
                     "'earliest' for backwards compatibility or 'latest' for "
                     "performance")
+parser.add_argument('-p', '--photon', type=Path,
+                    help='Path to photoatomic data library (eprdata12 or later)')
 parser.add_argument('mcnpdata', type=Path,
                     help='Directory containing endf71x and ENDF71SaB')
 args = parser.parse_args()
-assert args.mcnpdata.is_dir()
+
+# Check arguments to make sure they're valid
+assert args.mcnpdata.is_dir(), 'mcnpdata argument must be a directory'
+if args.photon is not None:
+    assert args.photon.is_file(), 'photon argument must be an existing file'
 
 # Get a list of all ACE files
-endf71x = list(args.mcnpdata.glob('endf71x/*/*.71?nc'))
+endf71x = list(args.mcnpdata.glob('endf71x/*/*.7??nc'))
 endf71sab = list(args.mcnpdata.glob('ENDF71SaB/*.??t'))
 
+# Check for fixed H1 files and remove old ones if present
+hydrogen = args.mcnpdata / 'endf71x' / 'H'
+if (hydrogen / '1001.720nc').is_file():
+    for i in range(10, 17):
+        endf71x.remove(hydrogen / f'1001.7{i}nc')
+
 # There's a bug in H-Zr at 1200 K
-endf71sab.remove(args.mcnpdata / 'ENDF71SaB' / 'h-zr.27t')
+thermal = args.mcnpdata / 'ENDF71SaB'
+endf71sab.remove(thermal / 'h-zr.27t')
+
+# Check for updated TSL files and remove old ones if present
+checks = [
+    ('sio2', 10, range(20, 37)),
+    ('u-o2', 30, range(20, 28)),
+    ('zr-h', 30, range(20, 28))
+]
+for material, good, bad in checks:
+    if (thermal / f'{material}.{good}t').is_file():
+        for suffix in bad:
+            f = thermal / f'{material}.{suffix}t'
+            if f.is_file():
+                endf71sab.remove(f)
 
 # Group together tables for the same nuclide
 tables = defaultdict(list)
@@ -83,9 +110,8 @@ for name, paths in sorted(tables.items()):
     library.register_file(h5_file)
 
 # Handle photoatomic data
-mcplib = args.mcnpdata / 'mcplib84'
-if mcplib.exists():
-    lib = openmc.data.ace.Library(mcplib)
+if args.photon is not None:
+    lib = openmc.data.ace.Library(args.photon)
 
     for table in lib.tables:
         # Convert first temperature for the table


### PR DESCRIPTION
Our MCNP library conversion scripts mentioned using the `mcplib84` photoatomic data library, which actually doesn't work with OpenMC because it doesn't contain photoelectric subshell cross sections. Only the newer `eprdata12` or `eprdata14` libraries are valid, so those are explicitly called out in the script now. Because they exist in a different directory in MCNP's distribution, there's now just a separate optional argument for specifying the path to the photon library.

Also, I learned that in the MCNP 6.2 distribution, there are a few data files that have been updated, but both old/new ones are present, so it's not sufficient to just glob for all files and convert. I've added some logic that selectively removes older ACE files in favor of the newer ones. This affects H1 and three thermal scattering materials (SiO2, UO2, and ZrH).

Once this is merged, I'll update the corresponding converted MCNP libraries on [openmc.org](https://openmc.org/lanl-data-libraries/).