### PR TITLE
Add Serpent depletion conversion script

### DIFF
--- a/data_formatting_tools.py
+++ b/data_formatting_tools.py
@@ -1,0 +1,131 @@
+import collections
+import json
+import os
+import pprint
+
+import pandas as pd
+import pymongo
+#from bson.code import Code
+import xlrd
+from pymongo import MongoClient
+
+
+def find_files_recursive(folder,extension,ignore):
+
+    list_of_files=[]
+
+    for root, dirs, files in os.walk(folder):
+        for file in files:
+          if file.endswith(extension) and not file.endswith(ignore):
+              list_of_files.append(os.path.join(root,file))
+    print('number of files found',len(list_of_files))
+    return list_of_files
+
+def find_files(data_folders,extension):
+    ''' function searches through folders and finds files ending with .txt or .csv
+        input: folder(s) to search through
+        input type: list of strings
+        returns: list of matching filenames
+    '''
+    list_of_filenames =[]
+    for folder in data_folders:
+        print(folder)
+        for file in os.listdir(folder):
+            if file.endswith(extension):
+                filename = os.path.join(folder ,file)
+                list_of_filenames.append(filename)
+    return list_of_filenames
+
+def convert_csv_files_to_dataframe_objects(filenames ,schema):
+    ''' Loads csv files into a pandas dataframe
+        checks that files match the schema
+        inputs: list of filenames, schema [optional]
+        input types: list of strings, list of strings
+    '''
+    list_of_dataframes =[]
+    for filename in filenames:
+        df = pd.read_csv(filename ,sep=',|\t')
+        for header in df.columns.values:
+            df.rename(columns={header: header.strip('\t .')}, inplace=True)
+        # print(df.columns.values)
+        if set(df.columns.values) == set(schema):
+            print('converting' ,filename, 'to dataframe')
+            list_of_dataframes.append(df)
+        else:
+            print("\x1b[31m\"" + str(filename) + ' does not conform to schema' + "\x1b[0m")
+    return list_of_dataframes
+
+def convert_dataframe_objects_to_json_files(list_of_dataframes, filenames):
+    ''' Converts pandas dataframe into a json file
+        inputs: list of dataframes
+        input types: list of dataframes
+    '''
+    list_of_filenames = []
+    for df, filename in zip(list_of_dataframes, filenames):
+        df.to_json(filename, orient='columns')
+        # df.to_json(filename, orient='columns', index=False) index setting is not currently supported, perhaps with the next release, see http://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.to_json.html?highlight=to_json#pandas.DataFrame.to_json
+        list_of_filenames.append(filename)
+    return list_of_filenames
+
+def apply_abs_operation_to_field(json_objects,field):
+    for json_object in json_objects:
+        json_object[field]=l = [abs(x) for x in json_object[field]]
+    return json_objects
+
+def read_in_json_files(filenames):
+    # read in json files
+    list_of_json_objects = []
+    for filename in filenames:
+        with open(filename) as f:
+            data = json.load(f)
+            data = remove_df_index_from_json_object(data)
+            list_of_json_objects.append(data)
+    return list_of_json_objects
+
+def convert_list_of_tuples_to_list(list_of_tuples):
+    list_of_single_values=[]
+    for x in range(0,len(list_of_tuples)):
+        list_of_single_values.append(list_of_tuples[str(x)])
+    return list_of_single_values
+
+def remove_df_index_from_json_object(data):
+    newdata={}
+    for key in data.keys():
+        #print(key)
+        list_of_tuples = data[key]
+        newdata[key] = convert_list_of_tuples_to_list(list_of_tuples) 
+    return newdata
+       
+# def write_json_files(json_objects, filenames):
+#     print('writing json files')
+#     list_of_json_objects = []
+#     for filename, json_object in zip(filenames, json_objects):
+#         with open(filename, 'w') as outfile:
+#             json.dump(json_object, outfile,  indent=4)
+#     return filenames
+
+def save_json_obj_to_file(json_obj,filename,folder=''):
+    print('saving data')
+    with open(os.path.join(folder,filename), 'w') as fout:
+        #json.dump(list_of_data, fout, encoding='utf-8', indent = 4) #python 2
+        json.dump(json_obj, fout, indent = 4)
+
+def save_json_objs_to_files(json_objs,folder=''):
+    for json_obj in json_objs:
+        save_json_obj_to_file(json_obj,json_obj['filename'],folder)
+
+
+def add_meta_data_to_json_objects(json_object, keyname, keyvalue):
+    # add some meta data to json file
+
+    if type(json_object) == list and type(keyname) == list and type(keyvalue) == list:
+        for item_json, item_keyname, item_keyvalue in zip(json_object, keyname, keyvalue):
+            item_json[item_keyname] = item_keyvalue
+            print('added new meta data list', item_keyname, ' = ', item_keyvalue)
+        return json_object
+    else:
+        json_object[keyname] = keyvalue
+        print('added new meta data', keyname, ' = ', keyvalue)
+        return json_object
+
+

--- a/database_tools.py
+++ b/database_tools.py
@@ -1,0 +1,188 @@
+import pandas as pd
+import os
+import json
+import pprint
+import collections
+import pymongo
+from pymongo import MongoClient
+from bson.code import Code
+import socket
+
+def connect_to_database(db_name='my_database',collection_name='collection_one'):
+    ''' Creates a local MongoDB database called my_database and connects to it
+        defaults are provided for the names
+    '''
+    client = MongoClient('localhost', 27017)
+    db = client[db_name]
+    collection = db[collection_name]
+    print('connected to database')
+    return collection, client, db
+
+def connect_to_docker_database(db_name='my_database',collection_name='collection_one'):
+    ''' Creates a local MongoDB database called my_database and connects to it
+    '''
+    host = socket.gethostbyname(socket.gethostname())
+    client = MongoClient(host, 27017)
+    db = client[db_name]
+    collection = db[collection_name]
+    print('connected to database')
+    return collection, client, db    
+
+def delete_database(client, db_name='my_database'):
+    try:
+      client.drop_database(db_name)
+      print('database deleted')
+    except:
+      print('unable to delete database',db_name)
+
+def upload_json_objects_to_database(data,collection):
+
+    if type(data)==list:
+        for i, item in enumerate(data):
+          try:
+            print('inserting entry into database ',i)
+            collection.insert_many(item)
+          except:
+            print('FAILED inserting entry into database',i)
+            # print('failing json object is ' ,item)
+
+    else:
+        collection.insert_one(data)
+    print('json object commited to database')
+
+#def get_database_fields(collection, query_fields_and_values={},ignore_fields=[]):
+def get_database_fields(collection,ignore_fields=[]):
+    mapper = Code("""
+                  function() {
+                              for (var key in this) { emit(key, null); }
+                             }
+                  """)
+
+    reducer = Code("""
+                   function(key, stuff) { return null; }
+                   """)
+
+    mr = collection.map_reduce(map =  mapper,
+                         reduce = reducer,
+                         #query = query_fields_and_values,
+                         out = "my_collection" + "_keys")
+    unique_fields = []
+    for doc in mr.find():
+       if doc["_id"] not in ignore_fields:
+           if doc["_id"] != "_id":
+               unique_fields.append(doc["_id"])
+    return unique_fields
+
+def get_entries_in_field(collection, field, query=None):
+    if query != {}:
+      result = collection.distinct(field,query)
+    else:
+      result = collection.distinct(field)
+    return result
+
+def get_type_of_entries_in_field(collection, field, query=None):
+    return type(collection.find_one({field:{ '$exists': True }})[field]).__name__
+    #return type(collection.find_one()[field]).__name__
+
+def find_all_fields_types_in_database(collection):
+    all_fields = get_database_fields(collection)
+    field_and_type = {}
+    for field in all_fields:
+      type_of_field_contents = get_type_of_entries_in_field(collection,field)
+      field_and_type[field] = type_of_field_contents
+    return field_and_type
+
+def find_all_fields_of_a_particular_types_in_database(collection,type_required):
+    all_fields = get_database_fields(collection)
+    field_of_correct_type = []
+    for field in all_fields:
+        type_of_field_contents = get_type_of_entries_in_field(collection,field)
+        if type_of_field_contents ==type_required:
+            field_of_correct_type.append(field)
+    return field_of_correct_type
+
+def find_all_fields_not_of_a_particular_types_in_database(collection,type_not_desired):
+    all_fields = get_database_fields(collection)
+    field_of_correct_type = []
+    for field in all_fields:
+        type_of_field_contents = get_type_of_entries_in_field(collection,field)
+        if type_of_field_contents !=type_not_desired:
+            field_of_correct_type.append(field)
+    return field_of_correct_type    
+
+def get_number_of_matching_entrys(collection, query_fields_and_values):
+    result = collection.find(query_fields_and_values)
+    return result.count()
+
+def get_matching_entrys(collection, query_fields_and_values,limit=10):
+    result = collection.find(query_fields_and_values).limit(limit)
+    return result
+
+def find_metadata_fields_and_their_distinct_values(collection, ignore_fields=[]):
+    meta_data_fields = get_database_fields(collection, ignore_fields)
+    metadata_fields_and_their_distinct_values={}
+    for entry in meta_data_fields:
+        values = get_entries_in_field(collection,entry)
+        # metadata_values.append(values)
+        metadata_fields_and_their_distinct_values[entry]=values
+
+    meta_data_fields_and_distinct_entries = []
+    for field in meta_data_fields:
+        meta_data_fields_and_distinct_entries.append({'field':[field],
+                                                      'distinct_values':metadata_fields_and_their_distinct_values[field]})
+    return meta_data_fields_and_distinct_entries
+
+
+def find_metadata_fields_and_their_distinct_values_and_types(collection, ignore_fields=[]):
+    meta_data_fields = get_database_fields(collection, ignore_fields)
+    metadata_fields_and_their_distinct_values={}
+    for entry in meta_data_fields:
+        values = get_entries_in_field(collection,entry)
+        # metadata_values.append(values)
+        metadata_fields_and_their_distinct_values[entry]=values
+
+
+
+    meta_data_fields_and_distinct_entries = []
+    for field in meta_data_fields:
+        meta_data_fields_and_distinct_entries.append({'field':[field],
+                                                      'distinct_values':metadata_fields_and_their_distinct_values[field],
+                                                      'type':type(metadata_fields_and_their_distinct_values[field])})
+    return meta_data_fields_and_distinct_entries
+
+
+if __name__ == '__main__':
+
+
+  collection, client, db = connect_to_database()
+  # collection, client, db = connect_to_docker_database()
+
+  query = {'mass number':5}
+
+  myresults=collection.find(query)
+
+  print('number of results found = ' ,myresults.count())
+
+  print('current reaction ',myresults[0]['reaction']) 
+
+ 
+
+
+
+  #collection.delete_one(myquery)
+
+
+  #results  = get_number_of_matching_entrys(collection, {'uploader':'shimwell'})
+  # results = find_metadata_fields_and_their_distinct_values_and_types(collection)
+  # for result in results:
+  #   print(result['type'])
+  # fields = get_database_fields(collection)
+  # for f in fields:
+  #   results = get_entries_in_field(collection,f)
+  #   type_of_results = get_type_of_entries_in_field(collection,f)
+  #   print(f, type_of_results)
+  #print(find_all_fields_types_in_database(collection))
+  # results = collection.find_one({'temperature':{ '$exists': True }})['temperature']
+  # print(results)
+
+  #print(find_all_fields_of_a_particular_types_in_database(collection,'list'))

--- a/extract_entire_lib.py
+++ b/extract_entire_lib.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+
+"""exstract_entire_lib.py: Exstracts xs vs energy data from h5 based library"""
+
+__author__      = "Jonathan Shimwell"
+
+import argparse
+import os
+from pathlib import Path
+import h5py
+import matplotlib.pyplot as plt
+import numpy as np
+# import openmc.data
+from tqdm import tqdm
+
+import openmc
+from openmc.data import *
+
+from data_formatting_tools import *
+from database_tools import *
+
+parser = argparse.ArgumentParser()
+parser.add_argument('-l', '--library',
+                    help='the name of the lirary for example fendl 3.1d endf B-VII.1')                    
+parser.add_argument('-d', '--dir_hdf5',
+                    default = None,
+                    help='directory containing hdf5 files"'),
+parser.add_argument('-j', '--dir_json',
+                    default = None,
+                    help='directory containing json files"'),   
+parser.add_argument('-i', '--ignore',
+                    nargs = '*',
+                    default = [],
+                    help='hdf5 files that are not added to the database"') 
+parser.add_argument('-c', '--commit',
+                   choices = ['yes','no'],
+                   default = 'yes',
+                   help = 'Adds the nuclear data to the mongo database')
+
+args = parser.parse_args()
+
+
+library=args.library
+files_to_ignore = args.ignore
+datapath = args.dir_hdf5
+if args.dir_json == None:
+    json_datapath = args.dir_hdf5
+else:
+    json_datapath = args.dir_json
+
+Path(json_datapath).mkdir(parents=True, exist_ok=True)
+
+print('ignoring ',files_to_ignore)
+list_of_json_objects = []
+# os.system('mongod --bind_ip_all &')
+
+# should be added to openmc data?
+ELEMENT_NAME = {0: 'neutron', 1: 'Hydrogen', 2: 'Helium', 3: 'Lithium',
+                 4: 'Beryllium', 5: 'Boron', 6: 'Carbon', 7: 'Nitrogen',
+                 8: 'Oxygen', 9: 'Fluorine', 10: 'Neon', 11: 'Sodium',
+                 12: 'Magnesium', 13: 'Aluminium', 14: 'Silicon',
+                 15: 'Phosphorus', 16: 'Sulfur', 17: 'Chlorine',
+                 18: 'Argon', 19: 'Potassium', 20: 'Calcium',
+                 21: 'Scandium', 22: 'Titanium', 23: 'Vanadium',
+                 24: 'Chromium', 25: 'Manganese', 26: 'Iron',
+                 27: 'Cobalt', 28: 'Nickel', 29: 'Copper', 30: 'Zinc',
+                 31: 'Gallium', 32: 'Germanium', 33: 'Arsenic',
+                 34: 'Selenium', 35: 'Bromine', 36: 'Krypton',
+                 37: 'Rubidium', 38: 'Strontium', 39: 'Yttrium',
+                 40: 'Zirconium', 41: 'Niobium', 42: 'Molybdenum',
+                 43: 'Technetium', 44: 'Ruthenium', 45: 'Rhodium',
+                 46: 'Palladium', 47: 'Silver', 48: 'Cadmium', 49: 'Indium',
+                 50: 'Tin', 51: 'Antimony', 52: 'Tellurium', 53: 'Iodine',
+                 54: 'Xenon', 55: 'Caesium', 56: 'Barium', 57: 'Lanthanum',
+                 58: 'Cerium', 59: 'Praseodymium', 60: 'Neodymium',
+                 61: 'Promethium', 62: 'Samarium', 63: 'Europium', 
+                 64: 'Gadolinium', 65: 'Terbium', 66: 'Dysprosium',
+                 67: 'Holmium', 68: 'Erbium', 69: 'Thulium',
+                 70: 'Ytterbium', 71: 'Lutetium', 72: 'Hafnium',
+                 73: 'Tantalum', 74: 'Tungsten', 75: 'Rhenium',
+                 76: 'Osmium', 77: 'Iridium', 78: 'Platinum',
+                 79: 'Gold', 80: 'Mercury', 81: 'Thallium',
+                 82: 'Lead', 83: 'Bismuth', 84: 'Polonium',
+                 85: 'Astatine', 86: 'Radon', 87: 'Francium',
+                 88: 'Radium', 89: 'Actinium', 90: 'Thorium',
+                 91: 'Protactinium', 92: 'Uranium', 93: 'Neptunium',
+                 94: 'Plutonium', 95: 'Americium', 96: 'Curium',
+                 97: 'Berkelium', 98: 'Californium', 99: 'Einsteinium',
+                 100: 'Fermium', 101: 'Mendelevium', 102: 'Nobelium',
+                 103: 'Lawrencium', 104: 'Rutherfordium', 105: 'Dubnium',
+                 106: 'Seaborgium', 107: 'Bohrium', 108: 'Hassium',
+                 109: 'Meitnerium', 110: 'Darmstadtium', 111: 'Roentgenium',
+                 112: 'Copernicium', 113: 'Nihonium', 114: 'Flerovium',
+                 115: 'Moscovium', 116: 'Livermorium', 117: 'Tennessine',
+                 118: 'Oganesson'}
+
+
+#from openmc reactions
+
+def find_REACTION_NAME(incident_particle_symbol, keynumber):
+    REACTION_NAME = {1: '('+incident_particle_symbol+',total)', 
+                    2: '('+incident_particle_symbol+',elastic)', 
+                    4: '('+incident_particle_symbol+',level)',
+                    5: '('+incident_particle_symbol+',misc)', 
+                    11: '('+incident_particle_symbol+',2nd)', 
+                    16: '('+incident_particle_symbol+',2n)', 
+                    17: '('+incident_particle_symbol+',3n)',
+                    18: '('+incident_particle_symbol+',fission)', 
+                    19: '('+incident_particle_symbol+',f)', 
+                    20: '('+incident_particle_symbol+',nf)', 
+                    21: '('+incident_particle_symbol+',2nf)',
+                    22: '('+incident_particle_symbol+',na)', 
+                    23: '('+incident_particle_symbol+',n3a)', 
+                    24: '('+incident_particle_symbol+',2na)', 
+                    25: '('+incident_particle_symbol+',3na)',
+                    27: '('+incident_particle_symbol+',absorption)', 
+                    28: '('+incident_particle_symbol+',np)', 
+                    29: '('+incident_particle_symbol+',n2a)',
+                    30: '('+incident_particle_symbol+',2n2a)', 
+                    32: '('+incident_particle_symbol+',nd)', 
+                    33: '('+incident_particle_symbol+',nt)', 
+                    34: '('+incident_particle_symbol+',nHe-3)',
+                    35: '('+incident_particle_symbol+',nd2a)', 
+                    36: '('+incident_particle_symbol+',nt2a)', 
+                    37: '('+incident_particle_symbol+',4n)', 
+                    38: '('+incident_particle_symbol+',3nf)',
+                    41: '('+incident_particle_symbol+',2np)', 
+                    42: '('+incident_particle_symbol+',3np)', 
+                    44: '('+incident_particle_symbol+',n2p)', 
+                    45: '('+incident_particle_symbol+',npa)',
+                    91: '('+incident_particle_symbol+',nc)', 
+                    101: '('+incident_particle_symbol+',disappear)', 
+                    102: '('+incident_particle_symbol+',gamma)',
+                    103: '('+incident_particle_symbol+',p)', 
+                    104: '('+incident_particle_symbol+',d)', 
+                    105: '('+incident_particle_symbol+',t)', 
+                    106: '('+incident_particle_symbol+',3He)',
+                    107: '('+incident_particle_symbol+',a)', 
+                    108: '('+incident_particle_symbol+',2a)', 
+                    109: '('+incident_particle_symbol+',3a)', 
+                    111: '('+incident_particle_symbol+',2p)',
+                    112: '('+incident_particle_symbol+',pa)', 
+                    113: '('+incident_particle_symbol+',t2a)', 
+                    114: '('+incident_particle_symbol+',d2a)', 
+                    115: '('+incident_particle_symbol+',pd)',
+                    116: '('+incident_particle_symbol+',pt)', 
+                    117: '('+incident_particle_symbol+',da)', 
+                    152: '('+incident_particle_symbol+',5n)', 
+                    153: '('+incident_particle_symbol+',6n)',
+                    154: '('+incident_particle_symbol+',2nt)', 
+                    155: '('+incident_particle_symbol+',ta)', 
+                    156: '('+incident_particle_symbol+',4np)', 
+                    157: '('+incident_particle_symbol+',3nd)',
+                    158: '('+incident_particle_symbol+',nda)', 
+                    159: '('+incident_particle_symbol+',2npa)', 
+                    160: '('+incident_particle_symbol+',7n)', 
+                    161: '('+incident_particle_symbol+',8n)',
+                    162: '('+incident_particle_symbol+',5np)', 
+                    163: '('+incident_particle_symbol+',6np)', 
+                    164: '('+incident_particle_symbol+',7np)', 
+                    165: '('+incident_particle_symbol+',4na)',
+                    166: '('+incident_particle_symbol+',5na)', 
+                    167: '('+incident_particle_symbol+',6na)', 
+                    168: '('+incident_particle_symbol+',7na)', 
+                    169: '('+incident_particle_symbol+',4nd)',
+                    170: '('+incident_particle_symbol+',5nd)', 
+                    171: '('+incident_particle_symbol+',6nd)', 
+                    172: '('+incident_particle_symbol+',3nt)', 
+                    173: '('+incident_particle_symbol+',4nt)',
+                    174: '('+incident_particle_symbol+',5nt)', 
+                    175: '('+incident_particle_symbol+',6nt)', 
+                    176: '('+incident_particle_symbol+',2n3He)',
+                    177: '('+incident_particle_symbol+',3n3He)', 
+                    178: '('+incident_particle_symbol+',4n3He)', 
+                    179: '('+incident_particle_symbol+',3n2p)',
+                    180: '('+incident_particle_symbol+',3n3a)', 
+                    181: '('+incident_particle_symbol+',3npa)', 
+                    182: '('+incident_particle_symbol+',dt)',
+                    183: '('+incident_particle_symbol+',npd)', 
+                    184: '('+incident_particle_symbol+',npt)', 
+                    185: '('+incident_particle_symbol+',ndt)',
+                    186: '('+incident_particle_symbol+',np3He)', 
+                    187: '('+incident_particle_symbol+',nd3He)', 
+                    188: '('+incident_particle_symbol+',nt3He)',
+                    189: '('+incident_particle_symbol+',nta)', 
+                    190: '('+incident_particle_symbol+',2n2p)', 
+                    191: '('+incident_particle_symbol+',p3He)',
+                    192: '('+incident_particle_symbol+',d3He)', 
+                    193: '('+incident_particle_symbol+',3Hea)', 
+                    194: '('+incident_particle_symbol+',4n2p)',
+                    195: '('+incident_particle_symbol+',4n2a)', 
+                    196: '('+incident_particle_symbol+',4npa)', 
+                    197: '('+incident_particle_symbol+',3p)',
+                    198: '('+incident_particle_symbol+',n3p)', 
+                    199: '('+incident_particle_symbol+',3n2pa)', 
+                    200: '('+incident_particle_symbol+',5n2p)', 
+                    444: '('+incident_particle_symbol+',damage)',
+                    649: '('+incident_particle_symbol+',pc)', 
+                    699: '('+incident_particle_symbol+',dc)', 
+                    749: '('+incident_particle_symbol+',tc)', 
+                    799: '('+incident_particle_symbol+',3Hec)',
+                    849: '('+incident_particle_symbol+',ac)', 
+                    891: '('+incident_particle_symbol+',2nc)'}
+    REACTION_NAME.update({i: '('+incident_particle_symbol+',n{})'.format(i - 50) for i in range(50, 91)})
+    REACTION_NAME.update({i: '('+incident_particle_symbol+',p{})'.format(i - 600) for i in range(600, 649)})
+    REACTION_NAME.update({i: '('+incident_particle_symbol+',d{})'.format(i - 650) for i in range(650, 699)})
+    REACTION_NAME.update({i: '('+incident_particle_symbol+',t{})'.format(i - 700) for i in range(700, 749)})
+    REACTION_NAME.update({i: '('+incident_particle_symbol+',3He{})'.format(i - 750) for i in range(750, 799)})
+    REACTION_NAME.update({i: '('+incident_particle_symbol+',a{})'.format(i - 800) for i in range(800, 849)})
+    REACTION_NAME.update({i: '('+incident_particle_symbol+',2n{})'.format(i - 875) for i in range(875, 891)})
+
+    REACTION_NAME[3]='('+incident_particle_symbol+',nonelastic)'
+    REACTION_NAME[203]='('+incident_particle_symbol+',Xp)'
+    REACTION_NAME[204]='('+incident_particle_symbol+',Xd)'
+    REACTION_NAME[205]='('+incident_particle_symbol+',Xt)'
+    REACTION_NAME[206]='('+incident_particle_symbol+',3He)'
+    REACTION_NAME[207]='('+incident_particle_symbol+',Xa)'
+    REACTION_NAME[301]='('+incident_particle_symbol+',heat)'
+    REACTION_NAME[901]='('+incident_particle_symbol+',displacement NRT)'
+
+    # for reaction in REACTION_NAME: 
+    #     REACTION_NAME[reaction] = REACTION_NAME[reaction][3:-1]
+
+    return REACTION_NAME[keynumber]
+
+number_of_entries_added_to_db = 0
+
+for file in tqdm(os.listdir(datapath)):
+    if file.endswith(".h5") and file not in files_to_ignore:
+        
+        print('trying ',os.path.join(datapath, file))
+
+        with h5py.File(os.path.join(datapath, file)) as h5file:
+            filetype = h5file.attrs['filetype'].decode()[5:] #same method as library.py
+
+        if filetype != 'thermal' and filetype != 'photon':
+
+            if filetype == 'neutron':
+                incident_particle_symbol = 'n'
+                isotope_object = openmc.data.IncidentNeutron.from_hdf5(os.path.join(datapath, file))
+            if filetype == 'photon':
+                incident_particle_symbol = 'p'
+                isotope_object = openmc.data.IncidentPhoton.from_hdf5(os.path.join(datapath, file))
+
+            reactions = isotope_object.reactions
+
+            temperatures = isotope_object.energy.keys()
+
+            for reaction in reactions:
+                temperatures = isotope_object[reaction].xs.keys()
+                for temperature in temperatures:
+                    energy = isotope_object.energy[temperature]
+                    cross_section = isotope_object[reaction].xs[temperature](energy)
+
+                    shorter_cross_section = np.trim_zeros(cross_section, 'f')
+
+                    ofset = len(cross_section) - len(shorter_cross_section)
+
+                    shorter_energy= energy[ofset:]
+
+                    if int(isotope_object._mass_number)!=0: #this prevents natural (e.g. Carbon)
+
+                        neutron_number = int(isotope_object._mass_number-isotope_object._atomic_number)
+                        mass_number = int(isotope_object._mass_number)
+
+                        # print('creating json object for ',isotope_object.name, 'MT',reaction, temperature)
+
+                        uuid = '_'.join([isotope_object.atomic_symbol, str(mass_number), library, incident_particle_symbol, str(int(reaction)), str(temperature)])
+
+                        # json_obj = {
+                        #     'Mass number':mass_number,
+                        #     'Proton number':int(isotope_object._atomic_number),
+                        #     'Neutron number':neutron_number,
+                        #     'Element':ELEMENT_NAME[int(isotope_object._atomic_number)],
+                        #     'Atomic symbol':isotope_object.atomic_symbol,
+                        #     'Temperature':temperature,
+                        #     'Incident particle':'neutron',
+                        #     'Reaction products':REACTION_NAME[int(reaction)],
+                        #     'MT reaction number':int(reaction), # mt number
+                        #     'Library':library,
+                        #     'cross section':shorter_cross_section.tolist(),
+                        #     'energy':shorter_energy.tolist(),
+                        # }
+
+                        json_obj = {
+                            'Proton number / element':str(int(isotope_object._atomic_number)) +' '+isotope_object.atomic_symbol + ' '  + ELEMENT_NAME[int(isotope_object._atomic_number)],
+                            'Mass number':mass_number,
+                            'Neutron number':neutron_number,
+                            'MT number / reaction products':str(int(reaction)) + ' ' +find_REACTION_NAME(incident_particle_symbol,int(reaction)),
+                            'Library':library,
+                            # 'Temperature':temperature,
+                            'cross section':shorter_cross_section.tolist(),
+                            'energy':shorter_energy.tolist(),
+                        }                        
+
+
+                        # list_of_json_objects.append(json_obj)
+                        print(uuid)
+                        with open(os.path.join(json_datapath,uuid+'.json'), 'w') as fout:
+                            json.dump(json_obj, fout)#, indent = 4)
+                        if args.commit == 'yes':
+                            print('mongoimport --collection collection_one --db my_database --file '+os.path.join(json_datapath,uuid+'.json'))
+                            os.system('mongoimport --collection collection_one --db my_database --file '+os.path.join(json_datapath,uuid+'.json'))
+                            number_of_entries_added_to_db=number_of_entries_added_to_db+1
+
+                    #os.system('rm '+os.path.join(datapath,'temp_json.json'))
+                
+        # except:
+        #     print('failed ',os.path.join(datapath, file))
+
+# save_json_objs_to_files(list_of_json_objects,datapath
+
+# with open(os.path.join(folder,filename), 'w') as fout:
+    #json.dump(list_of_data, fout, encoding='utf-8', indent = 4) #python 2
+    
+# os.system('mongod --bind_ip_all &')
+# collection, client, db = connect_to_docker_database()
+# # delete_database(client)
+# # collection.insert_many(list_of_json_objects)
+# # upload_json_objects_to_database(list_of_json_objects, collection)
+
+# all_database_fields = get_database_fields(collection)
+
+# print('all_database_fields',all_database_fields)
+
+# entrys_in_field_1 = get_entries_in_field(collection,all_database_fields[0])
+
+# print('entrys_in_field',all_database_fields[0], entrys_in_field_1)
+# print(collection.find_one({}))
+# print(list_of_xs)
+
+        #new_xs = {'temperature'}
+#             energy = isotope_object.energy['293K'] # 294K is the temperature for tendl this is 293K
+#             cross_section = isotope_object[MT_number].xs['293K'](energy)
+
+if args.commit == 'yes':
+    print('number_of_entries_added_to_db', number_of_entries_added_to_db)

--- a/generate_serpent_chain.py
+++ b/generate_serpent_chain.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""
+Generate an equivalent depletion chain from Serpent data.
+
+Two additional files are typically distributed with the Serpent
+Monte Carlo code:
+
+1) Radioactive decay file, typically ``sss_endfb7.dec``, and
+2) Neutron-induced fission product yields, typically ``sss_endfb7.nfy.
+
+These files can be used to create a :class:`openmc.deplete.Chain`, but
+some cleanup steps have to be taken.
+
+First, the files appear to be ENDF-6 formatted files concatenated
+together. Unfortunately, there is a TEND record after each dataset,
+so :func:`openmc.data.endf.get_evaluations` will only read and return
+the first evaluation. For this reason, we must read the file until
+all records have been found manually.
+
+Secondly, the decay file does not have a tape indent (TPID) record,
+which can throw off the first reading. This exception can be caught,
+but it currently involves skipping the first item in the file. At the
+time of this writing, this skipped item contains the decay data for a
+neutron.
+
+Lastly, there is a single negative uncertainty in the Co-55 k-shell
+conversion energies. This quantity is not used in the depletion chain,
+but it must be altered to prevent downstream failures.
+"""
+import os
+import sys
+from pathlib import Path
+import argparse
+import warnings
+
+from openmc.data.endf import Evaluation
+from openmc.deplete import Chain
+
+# Make sure Python version is sufficient
+assert sys.version_info >= (3, 6), "Python 3.6+ is required"
+
+
+def get_decay_evals(decpath: Path):
+    """Find all but the first decay record in the file
+
+    Due to the lack of a TPID entry, the first line is skipped,
+    throwing off the rest of the read process. The exception is
+    caught, but the first decay item (neutron decay) is not stored.
+
+    Co-55 fix is described here:
+    https://github.com/openmc-dev/openmc/pull/1452#issuecomment-576773726
+    """
+    out = []
+    EXPECTED_ASSERT = 1
+    counted_assert = 0
+    with decpath.open("r") as stream:
+        while True:
+            try:
+                ev = Evaluation(stream)
+            except AssertionError:
+                if counted_assert < EXPECTED_ASSERT:
+                    counted_assert += 1
+                    continue
+                raise
+            except ValueError:
+                break
+            if ev.gnd_name == "Co55":
+                # Fix negative uncertainty
+                sec = ev.section[8, 457]
+                ev.section[8, 457] = "0".join([sec[:762], sec[764:]])
+            out.append(ev)
+    print(f"Found {len(out)} items in {decpath}")
+    print(f"  First: {out[0]}\n  Last: {out[-1]}")
+    return out
+
+
+def get_fpy_evals(fpypath: Path):
+    """Obtain neutron-induced fission product yields from file"""
+    # Can't use get_evaluations or else only one is returned
+    out = []
+    with fpypath.open("r") as stream:
+        while stream:
+            try:
+                ev = Evaluation(stream)
+            except ValueError:
+                break
+            out.append(ev)
+    print(f"Found {len(out)} items in {fpypath}")
+    print(f"  First: {out[0]}\n  Last: {out[-1]}")
+    return out
+
+
+class CustomFormatter(
+    argparse.ArgumentDefaultsHelpFormatter,
+    argparse.RawDescriptionHelpFormatter,
+):
+    pass
+
+
+parser = argparse.ArgumentParser(
+    description="""Generate an equivalent depletion chain from Serpent data""",
+    formatter_class=CustomFormatter,
+)
+
+parser.add_argument(
+    "nfy", type=Path, help="Path to neutron-induced fission yield file",
+)
+
+parser.add_argument(
+    "dec", type=Path, help="Path to radioactive decay file",
+)
+
+parser.add_argument(
+    "--neutron-dir",
+    type=Path,
+    help=(
+        "Path to ENDF-formatted incident neutron data. Defaults to pull "
+        "data from OPENMC_ENDF_DATA if not provided"
+    ),
+)
+
+
+parser.add_argument(
+    "--branches-from",
+    type=Path,
+    help="Pull branching ratios from existing XML depletion chain",
+)
+
+parser.add_argument(
+    "-o",
+    "--output",
+    type=Path,
+    help="Write new depletion chain to this file",
+    default="serpent_chain.xml",
+)
+
+args = parser.parse_args()
+
+if not args.nfy.is_file():
+    raise FileNotFoundError(args.nfy)
+
+if not args.dec.is_file():
+    raise FileNotFoundError(args.dec)
+
+if args.neutron_dir is None:
+    endfd = os.environ.get("OPENMC_ENDF_DATA")
+    if endfd is None:
+        raise EnvironmentError(
+            "Need to pass neutron directory or set OPENMC_ENDF_DATA "
+            "environment variable to find neutron reaction data"
+        )
+    neutron_dir = Path(endfd) / "neutrons"
+else:
+    neutron_dir = args.neutron_dir
+
+if not neutron_dir.is_dir():
+    raise NotADirectoryError(neutron_dir)
+
+if args.output.exists() and not args.output.is_file():
+    raise IOError(f"{args.output} exists but is not a file")
+
+nfy_evals = get_fpy_evals(args.nfy)
+dec_evals = get_decay_evals(args.dec)
+neutrons = neutron_dir.glob("*.endf")
+
+chain = Chain.from_endf(dec_evals, nfy_evals, neutrons)
+
+if args.branches_from is not None:
+    if not args.branches_from.is_file():
+        raise FileNotFoundError(args.branches_from)
+    other_br = Chain.from_xml(args.branches_from).get_branch_ratios()
+    if other_br:
+        chain.set_branch_ratios(other_br)
+    else:
+        warnings.warn(
+            f"No branching ratios found in {args.branches_from}",
+            RuntimeWarning,
+        )
+
+chain.export_to_xml(args.output)


### PR DESCRIPTION
Creates an equivalent depletion chain using decay and fission yield files distributed with Serpent. Some steps are taken to clean up and fix a few issues. The fixes are detailed in the script and here for completeness.

First, the files appear to be ENDF-6 formatted files concatenated together. Unfortunately, there is a TEND record after each dataset, so :func:`openmc.data.endf.get_evaluations` will only read and return the first evaluation. For this reason, we must read the file until all records have been found manually.

Secondly, the decay file does not have a tape indent (TPID) record, which can throw off the first reading. This exception can be caught, but it currently involves skipping the first item in the file. At the time of this writing, this skipped item contains the decay data for a
neutron.

Lastly, there is a single negative uncertainty in the Co-55 k-shell conversion energies. This quantity is not used in the depletion chain, but it must be altered to prevent downstream failures.
- Source: https://github.com/openmc-dev/openmc/pull/1452#issuecomment-576050934
- Fix: https://github.com/openmc-dev/openmc/pull/1452#issuecomment-576773726

Supports reading in an additional chain file and applying branching ratios prior to exiting.

## Postscript

I am very open to suggestions on this. I tried making a fake decay file with a blank line at the top to get around
https://github.com/openmc-dev/openmc/blob/3f5373c71bd8331a18c61637214fb2372dcd47b3/openmc/data/endf.py#L408-L413
with out a lot of success.

## Post-postscript
Also, the code is formatted with [`black`](https://github.com/psf/black) which explains some of the lines with just closing parenthesis or single-argument lines. 