### PR TITLE
Add all releases and photon data to FENDL processing script

### DIFF
--- a/convert_fendl.py
+++ b/convert_fendl.py
@@ -13,8 +13,8 @@ import openmc.data
 from openmc._utils import download
 
 description = """
-Download FENDL 3.1d or FENDL 3.1c ACE data from the IAEA and convert it to a HDF5 library for
-use with OpenMC.
+Download FENDL-3.1d, FENDL-3.1a, FENDL-3.0 or FENDL-2.1  ACE data from the IAEA 
+and convert it to a HDF5 library for use with OpenMC.
 
 """
 
@@ -42,7 +42,7 @@ parser.add_argument('--libver', choices=['earliest', 'latest'],
                     default='earliest', help="Output HDF5 versioning. Use "
                     "'earliest' for backwards compatibility or 'latest' for "
                     "performance")
-parser.add_argument('-r', '--release', choices=['3.1a', '3.1d', '3.0', '2.1'],
+parser.add_argument('-r', '--release', choices=['3.1d', '3.1a', '3.0', '2.1'],
                     default='3.1d', help="The nuclear data library release version. "
                     "The currently supported options are 3.1d, 3.1a, 3.0 and "
                     "2.1")
@@ -165,6 +165,67 @@ release_details = {
     }
 }
 
+# Function to split an ENDF file made up of multiple evaluations into seperate
+# files, each with one evaluation.
+def split_endf(filename):
+    """Divides a file which contains multiple ENDF entries into individual 
+       ENDF files.
+
+        Parameters 
+        ----------
+        filename : str
+            Path to file with multiple ENDF records
+        
+        Returns
+        -------
+        list
+            A list of the names of files created
+    """
+        
+    with open(str(filename), 'r') as fh:
+  
+        current_file_str = ''
+        last_line_no = 0
+        created_files = []
+
+        # When cut the ENDF sections don't have seperate headers. Copy the main
+        # header to include in every file
+        header_line = fh.readline()
+        current_file_str += header_line
+
+        for line in fh:
+            
+            current_line_no = int(line.split()[-1])
+            
+            # Start of a new nuclide
+            if current_line_no < last_line_no:
+                # Create a temporary file with the data 
+                new_endf = open('tmp', 'w+')
+                new_endf.write(current_file_str)
+                new_endf.seek(0)
+
+                # Read the name of the new nuclide
+                items = openmc.data.endf.get_head_record(fh)
+                Z, A = divmod(items[0], 1000)
+
+                new_endf.close()
+                
+                new_filename = openmc.data.data.ATOMIC_SYMBOL[Z]
+                new_filename = new_filename + str(A) + ".endf"
+
+                os.rename('tmp', new_filename)
+                created_files.append(new_filename)
+                
+                # Reset for the next ENDF file
+                if current_line_no == 1:
+                    # Prepend a header if the next ENDF doesn't have one
+                    current_file_str = header_line
+
+            current_file_str += line
+            last_line_no = current_line_no
+        
+        return created_files
+
 compressed_file_size, uncompressed_file_size = 0, 0
 for p in ('neutron', 'photon'):
     if p in args.particles:
@@ -183,12 +244,10 @@ if args.download:
     print(download_warning)
 
     for particle in args.particles:
-        if args.release == '2.1':
-            # Older releases have ace files in individual zip files. Create a 
-            # a directory to hold them.
-            particle_download_path = download_path / particle
-            particle_download_path.mkdir(parents = True, exist_ok=True) 
-            os.chdir(particle_download_path)
+        # Create a directory to hold the downloads
+        particle_download_path = download_path / particle
+        particle_download_path.mkdir(parents = True, exist_ok=True) 
+        os.chdir(particle_download_path)
 
         particle_details = release_details[args.release][particle]
         for f in particle_details['files']:
@@ -201,8 +260,7 @@ if args.download:
 # EXTRACT FILES FROM ZIP
 if args.extract:
     for particle in args.particles:
-        if args.release == '2.1':
-            os.chdir(download_path / particle)
+        os.chdir(download_path / particle)
 
         particle_details = release_details[args.release][particle]
         if particle_details['file_type'] == "ace":
@@ -220,7 +278,7 @@ if args.extract:
         
     os.chdir(cwd)
     
-    if args.release == '2.1' and  args.cleanup and download_path.exists():
+    if args.cleanup and download_path.exists():
         rmtree(download_path)
 
     # Seperate photon ENDF file for 2.1 release
@@ -229,46 +287,7 @@ if args.extract:
         # from_endf method only reads the first nuclide. 
         # This splits the file down into seperate ENDF files for later reading.
         os.chdir(endf_files_dir)
-        
-        current_file_str = ''
-        last_line_no = 0
-
-        with open('FENDLEP.DAT', 'r') as base_file:
-            # When cut the ENDF sections don't have seperate headers. Copy the main
-            # header to include in every file
-            header_line = base_file.readline()
-            current_file_str += header_line
-            
-            for line in base_file:
-                
-                current_line_no = int(line.split()[-1])
-                
-                # Start of a new nuclide
-                if current_line_no < last_line_no:
-                    # Create a temporary file with the data 
-                    new_endf = open('tmp', 'w+')
-                    new_endf.write(current_file_str)
-                    new_endf.seek(0)
-                    
-                    # Use the ENDF evaluation method to read the name
-                    ev = openmc.data.endf.Evaluation(new_endf)
-                    new_endf.close()
-                    
-                    z = ev.target['atomic_number']
-                    a = ev.target['mass_number']
-                    new_filename = openmc.data.data.ATOMIC_SYMBOL[z]
-                    new_filename = new_filename + str(a) + ".endf"
-
-                    os.rename('tmp', new_filename)
-                    
-                    # Need to add a header line if there isn't one at the start of
-                    # new nuclide
-                    if current_line_no == 1:
-                        current_file_str = header_line
-
-                current_file_str += line
-                last_line_no = current_line_no
-        
+        split_endf('FENDLEP.DAT')
         os.chdir(cwd)
 
 # ==============================================================================

--- a/convert_fendl.py
+++ b/convert_fendl.py
@@ -68,9 +68,6 @@ args = parser.parse_args()
 
 # Function to check for k-39 error in FENDL-3.0
 def fendl30_k39(file_path):
-    err_msg = ''
-    skip_file = False
-    
     if 'Inf' in open(file_path, 'r').read():
         ace_error_warning = """ 
         {} contains 'Inf' values within the XSS array 
@@ -78,9 +75,9 @@ def fendl30_k39(file_path):
         in FENDL-3.0. {} has not been added to the cross section library. 
         """.format(file_path, file_path.name)
         err_msg = dedent(ace_error_warning)
-        skip_file = True
-
-    return {'skip_file': skip_file, 'err_msg': err_msg}
+        return {'skip_file': True, 'err_msg': err_msg}
+    else:
+        return {'skip_file': False}
 
 # Helper function for checking if there are any special cases defined:
 # Returns the special Cases relevant to a specific part of the script. 
@@ -252,7 +249,7 @@ if args.extract:
             # Check if file requires special handling
             if f in special_cases:
                 ret = special_cases[f](Path(f))
-                if len(ret['err_msg']) > 0:
+                if 'err_msg' in ret:
                     output_warnings.append(ret['err_msg'])
                 if ret['skip_file']:
                     continue
@@ -295,7 +292,7 @@ for particle in args.particles:
             # Handling for special cases
             if filename.name in special_cases:
                 ret = special_cases[filename.name](filename)
-                if len(ret['err_msg']) > 0:
+                if 'err_msg' in ret:
                     output_warnings.append(ret['err_msg'])
                 if ret['skip_file']:
                     continue
@@ -320,7 +317,7 @@ for particle in args.particles:
             # Check if file requires special handling
             if photo_path.name in special_cases:
                 ret = special_cases[photo_path.name](photo_path)
-                if len(ret['err_msg']) > 0:
+                if 'err_msg' in ret:
                     output_warnings.append(ret['err_msg'])
                 if ret['skip_file']:
                     continue
@@ -347,4 +344,4 @@ library.export_to_xml(args.destination / 'cross_sections.xml')
 
 # Print any warnings
 for warning in output_warnings:
-        warnings.warn(warning, Warning)
+    warnings.warn(warning)

--- a/convert_fendl.py
+++ b/convert_fendl.py
@@ -273,8 +273,6 @@ if args.extract:
             # unfortunatly which is incompatible with the standard python zipfile library
             # therefore the following system command is used
             subprocess.call(['unzip', '-o', f, '-d', extraction_dir])
-            if args.cleanup and Path(f).exists():
-                Path(f).unlink()
         
     os.chdir(cwd)
     

--- a/convert_fendl.py
+++ b/convert_fendl.py
@@ -205,13 +205,13 @@ def split_endf(filename):
                 new_endf.seek(0)
 
                 # Read the name of the new nuclide
-                items = openmc.data.endf.get_head_record(fh)
-                Z, A = divmod(items[0], 1000)
-
+                ev = openmc.data.endf.Evaluation(new_endf)
                 new_endf.close()
                 
-                new_filename = openmc.data.data.ATOMIC_SYMBOL[Z]
-                new_filename = new_filename + str(A) + ".endf"
+                z = ev.target['atomic_number']
+                a = ev.target['mass_number']
+                new_filename = openmc.data.data.ATOMIC_SYMBOL[z]
+                new_filename = new_filename + str(a) + ".endf"
 
                 os.rename('tmp', new_filename)
                 created_files.append(new_filename)


### PR DESCRIPTION
This pull request contains changes related to issue #21 

I have included the following in the convert_fendl script:

- Photon data for FENDL-3.1a
- Photon data for FENDL-3.1d
- Neutron and Photon data for FENDL-3.0 
- Neutron and Photon data for FENDL-2.1

I also attempted to add FENDL-2.0 but faced problems because one of the energy laws required was not supported. This was discussed in #21 and an [issue](https://github.com/openmc-dev/openmc/issues/1487) was added to the main OpenMC repository 

I had some issues integrating FENDL-3.0 as K-39 ace file contained 'Inf' values within the data. OpenMC is unable to deal with this and cannot convert the file to HDF5. Although I looked into generating the file using the NJOY functionality built into OpenMC, it was decided that it was best to exclude K-39 (see #21 for more details). I have implemented a check and warning to test if the offending ace file is being processed. 

The FENDL-2.1 release is downloaded as individual ace files as it is not available in the same format as other releases. I thought it was best to create a download folder rather than download them in the current working directory.

Photo ENDF data for FENDL-2.1 is all within a single ENDF file. As such I added functionality which divides the file up into individual ENDF files before processing. I could not see a straight forward method of processing the file undivided with the incident photon class.

I've added a --cleanup and corresponding --no-cleanup argument which can be passed to remove the downloaded files. The --no-cleanup option is the default and its inclusion is slightly redundant but it follows the style of the other arguments. I chose to do --no-cleanup by default as this is the behavior of all the other convert scripts.

I have checked to make sure that the HDF5 files are generated for the added releases/particles and have checked the `cross_sections.xml` file contains the required libs. 