### PR TITLE
implemented pool processing for NJOY calls

### DIFF
--- a/generate_cendl.py
+++ b/generate_cendl.py
@@ -130,10 +130,8 @@ with Pool() as pool:
                 text[203] = '21)   Day R.B. and Walt M.  Phys.rev.117,1330 (1960)               525 1451  203'
             open(filename, 'w').write('\r\n'.join(text))
 
-        r = pool.apply_async(process_neutron,
-                             (filename,
-                             args.destination,
-                             args.libver))
+        func_args = (filename, args.destination, args.libver)
+        r = pool.apply_async(process_neutron, func_args)
         results.append(r)
 
     for r in results:

--- a/generate_endf71.py
+++ b/generate_endf71.py
@@ -220,18 +220,14 @@ if 'neutron' in args.particles:
         details = release_details[release][particle]
         results = []
         for filename in details['endf_files']:
-            r = pool.apply_async(process_neutron,
-                                 (filename,
-                                 args.destination / particle,
-                                 args.libver,
-                                 temperatures))
+            func_args = (filename, args.destination, args.libver, temperatures)
+            r = pool.apply_async(process_neutron, func_args)
             results.append(r)
 
         for path_neutron, path_thermal in details['sab_files']:
-            r = pool.apply_async(process_thermal,
-                                 (path_neutron, path_thermal,
-                                 args.destination / particle,
-                                 args.libver))
+            func_args = (path_neutron, path_thermal,
+                         args.destination / particle, args.libver)
+            r = pool.apply_async(process_thermal, func_args)
 
             results.append(r)
 

--- a/generate_endf71.py
+++ b/generate_endf71.py
@@ -9,14 +9,13 @@ used for OpenMC's regression test suite.
 import argparse
 import sys
 import tarfile
-import warnings
 import zipfile
 from multiprocessing import Pool
 from pathlib import Path
 from shutil import rmtree
 
 import openmc.data
-from utils import download
+from utils import download, process_neutron, process_thermal
 
 # Make sure Python version is sufficient
 assert sys.version_info >= (3, 6), "Python 3.6+ is required"
@@ -58,38 +57,6 @@ parser.add_argument('--no-cleanup', dest='cleanup', action='store_false',
                     "been processed")
 parser.set_defaults(download=True, extract=True, cleanup=False)
 args = parser.parse_args()
-
-
-def process_neutron(path, output_dir):
-    """Process ENDF neutron sublibrary file into HDF5 and write into a
-    specified output directory."""
-    try:
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore', UserWarning)
-            data = openmc.data.IncidentNeutron.from_njoy(
-                path, temperatures=temperatures
-            )
-    except Exception as e:
-        print(path, e)
-        raise
-    data.export_to_hdf5(output_dir / f'{data.name}.h5', 'w', libver=args.libver)
-    print(f'Finished {path}')
-
-
-def process_thermal(path_neutron, path_thermal, output_dir):
-    """Process ENDF thermal scattering sublibrary file into HDF5 and write into a
-    specified output directory."""
-    try:
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore', UserWarning)
-            data = openmc.data.ThermalScattering.from_njoy(
-                path_neutron, path_thermal
-            )
-    except Exception as e:
-        print(path_neutron, path_thermal, e)
-        raise
-    data.export_to_hdf5(output_dir / f'{data.name}.h5', 'w', libver=args.libver)
-    print(f'Finished {path_thermal}')
 
 
 def sort_key(path):
@@ -254,14 +221,17 @@ if 'neutron' in args.particles:
         results = []
         for filename in details['endf_files']:
             r = pool.apply_async(process_neutron,
-                                (filename,
-                                args.destination / particle))
+                                 (filename,
+                                 args.destination / particle,
+                                 args.libver,
+                                 temperatures))
             results.append(r)
 
         for path_neutron, path_thermal in details['sab_files']:
             r = pool.apply_async(process_thermal,
-                                (path_neutron, path_thermal,
-                                args.destination / particle))
+                                 (path_neutron, path_thermal,
+                                 args.destination / particle,
+                                 args.libver))
 
             results.append(r)
 

--- a/generate_jendl.py
+++ b/generate_jendl.py
@@ -121,10 +121,8 @@ with Pool() as pool:
     results = []
     for filename in sorted(neutron_files):
 
-        r = pool.apply_async(process_neutron,
-                             (filename,
-                             args.destination,
-                             args.libver))
+        func_args = (filename, args.destination, args.libver)
+        r = pool.apply_async(process_neutron, func_args)
         results.append(r)
 
     for r in results:

--- a/utils.py
+++ b/utils.py
@@ -24,7 +24,6 @@ def process_neutron(path, output_dir, libver, temperatures=None):
     h5_file = output_dir / f'{data.name}.h5'
     print(f'Writing {h5_file} ...')
     data.export_to_hdf5(h5_file, 'w', libver=libver)
-    return h5_file
 
 
 def process_thermal(path_neutron, path_thermal, output_dir, libver):
@@ -43,7 +42,6 @@ def process_thermal(path_neutron, path_thermal, output_dir, libver):
     h5_file = output_dir / f'{data.name}.h5'
     print(f'Writing {h5_file} ...')
     data.export_to_hdf5(h5_file, 'w', libver=libver)
-    return h5_file
 
 
 def download(url, checksum=None, as_browser=False, output_path=None, **kwargs):

--- a/utils.py
+++ b/utils.py
@@ -1,9 +1,49 @@
 import hashlib
+import warnings
+import openmc.data
 from pathlib import Path
 from urllib.parse import urlparse
 from urllib.request import urlopen, Request
 
 _BLOCK_SIZE = 16384
+
+
+def process_neutron(path, output_dir, libver, temperatures=None):
+    """Process ENDF neutron sublibrary file into HDF5 and write into a
+    specified output directory."""
+    print(f'Converting: {path}')
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', UserWarning)
+            data = openmc.data.IncidentNeutron.from_njoy(
+                path, temperatures=temperatures
+            )
+    except Exception as e:
+        print(path, e)
+        raise
+    h5_file = output_dir / f'{data.name}.h5'
+    print(f'Writing {h5_file} ...')
+    data.export_to_hdf5(h5_file, 'w', libver=libver)
+    return h5_file
+
+
+def process_thermal(path_neutron, path_thermal, output_dir, libver):
+    """Process ENDF thermal scattering sublibrary file into HDF5 and write into a
+    specified output directory."""
+    print(f'Converting: {path_thermal}')
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', UserWarning)
+            data = openmc.data.ThermalScattering.from_njoy(
+                path_neutron, path_thermal
+            )
+    except Exception as e:
+        print(path_neutron, path_thermal, e)
+        raise
+    h5_file = output_dir / f'{data.name}.h5'
+    print(f'Writing {h5_file} ...')
+    data.export_to_hdf5(h5_file, 'w', libver=libver)
+    return h5_file
 
 
 def download(url, checksum=None, as_browser=False, output_path=None, **kwargs):
@@ -39,7 +79,7 @@ def download(url, checksum=None, as_browser=False, output_path=None, **kwargs):
 
         local_path = Path(Path(urlparse(url).path).name)
         if output_path is not None:
-            Path(output_path).mkdir(parents=True, exist_ok=True) 
+            Path(output_path).mkdir(parents=True, exist_ok=True)
             local_path = output_path / local_path
         # Check if file already downloaded
         if local_path.is_file():


### PR DESCRIPTION
The script generate_endf71.py makes use of a multiprocessing pool to speed up the processing of endf files. This processing is done with NJOY and can take a while when there are a lot of files.

This PR is an attempt to bring this speed up to other scripts that generate h5 files from endf files with NJOY such as generate_jendl.py and gnerate_cendl.py.

This is achieved by moving two functions (process_neutron and process_thermal) from the generate_endf.py script into the utils.py script so that all the generate scripts can make use of them.

The multiprocessing pool is then implemented in the generate_jendl.py and gnerate_cendl.py scripts.

This PR was inspired by an PR in OpenMC which fixes a bug with parallel use of NJOY https://github.com/openmc-dev/openmc/pull/1522

I would recommend waiting till the OpenMC PR is merged before trying these new generate scripts.