### PR TITLE
Make sure neutron data goes to neutron/ directory

### DIFF
--- a/generate_endf71.py
+++ b/generate_endf71.py
@@ -220,7 +220,8 @@ if 'neutron' in args.particles:
         details = release_details[release][particle]
         results = []
         for filename in details['endf_files']:
-            func_args = (filename, args.destination, args.libver, temperatures)
+            func_args = (filename, args.destination / particle, args.libver,
+                         temperatures)
             r = pool.apply_async(process_neutron, func_args)
             results.append(r)
 
@@ -228,7 +229,6 @@ if 'neutron' in args.particles:
             func_args = (path_neutron, path_thermal,
                          args.destination / particle, args.libver)
             r = pool.apply_async(process_thermal, func_args)
-
             results.append(r)
 
         for r in results:

--- a/generate_jendl.py
+++ b/generate_jendl.py
@@ -120,7 +120,6 @@ library = openmc.data.DataLibrary()
 with Pool() as pool:
     results = []
     for filename in sorted(neutron_files):
-
         func_args = (filename, args.destination, args.libver)
         r = pool.apply_async(process_neutron, func_args)
         results.append(r)


### PR DESCRIPTION
Looks like we missed one detail in the refactor of generate_endf71.py. The generated neutron HDF5 files were not actually getting put in the `neutron/` output directory (and also wouldn't appear in the resulting cross_sections.xml file consequently.