### PR TITLE
Add scripts related to photon data

### DIFF
--- a/convert_lib80x.py
+++ b/convert_lib80x.py
@@ -35,14 +35,18 @@ parser.add_argument('--libver', choices=['earliest', 'latest'],
                     "'earliest' for backwards compatibility or 'latest' for "
                     "performance")
 parser.add_argument('datadir', type=Path,
-                    help='Directory containing Lib80x and ENDF80SaB')
+                    help='Directory containing Lib80x and ENDF80SaB/ENDF80SaB2')
 
 args = parser.parse_args()
 assert args.datadir.is_dir()
 
 # Get a list of all ACE files
 lib80x = list(args.datadir.glob('Lib80x/**/*.80?nc'))
-lib80sab = list(args.datadir.glob('ENDF80SaB/**/*.??t'))
+if (args.datadir / 'ENDF80SaB2').is_dir():
+    thermal_dir = args.datadir / 'ENDF80SaB2'
+else:
+    thermal_dir = args.datadir / 'ENDF80SaB'
+lib80sab = list(thermal_dir.glob('**/*.??t'))
 
 # Find and fix B10 ACE files
 b10files = list(args.datadir.glob('Lib80x/**/5010.80?nc'))

--- a/make_compton.py
+++ b/make_compton.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-import os
+from pathlib import Path
 import tarfile
 
 import numpy as np
@@ -10,7 +10,8 @@ from utils import download
 
 
 base_url = 'http://geant4.cern.ch/support/source/'
-filename = 'G4EMLOW.6.48.tar.gz'
+version = '6.48'
+filename = f'G4EMLOW.{version}.tar.gz'
 
 # ==============================================================================
 # DOWNLOAD FILES FROM GEANT4 SITE
@@ -20,9 +21,10 @@ download(base_url + filename)
 # ==============================================================================
 # EXTRACT FILES FROM TGZ
 
-if not os.path.isdir('G4EMLOW6.48'):
+g4dir = Path(f'G4EMLOW{version}')
+if not g4dir.is_dir():
     with tarfile.open(filename, 'r') as tgz:
-        print('Extracting {}...'.format(filename))
+        print(f'Extracting {filename}...')
         tgz.extractall()
 
 # ==============================================================================
@@ -30,19 +32,19 @@ if not os.path.isdir('G4EMLOW6.48'):
 
 print('Generating compton_profiles.h5...')
 
-shell_file = os.path.join('G4EMLOW6.48', 'doppler', 'shell-doppler.dat')
+shell_file = g4dir / 'doppler' / 'shell-doppler.dat'
 
 with open(shell_file, 'r') as shell, h5py.File('compton_profiles.h5', 'w') as f:
     # Read/write electron momentum values
-    pz = np.loadtxt(os.path.join('G4EMLOW6.48', 'doppler', 'p-biggs.dat'))
+    pz = np.loadtxt(g4dir / 'doppler' / 'p-biggs.dat')
     f.create_dataset('pz', data=pz)
 
     for z in range(1, 101):
         # Create group for this element
-        group = f.create_group('{:03}'.format(z))
+        group = f.create_group(f'{z:03}')
 
         # Read data into one long array
-        path = os.path.join('G4EMLOW6.48', 'doppler', 'profile-{}.dat'.format(z))
+        path = g4dir / 'doppler' / f'profile-{z}.dat'
         with open(path, 'r') as profile:
             j = np.fromstring(profile.read(), sep=' ')
 

--- a/make_compton.py
+++ b/make_compton.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+
+import os
+import tarfile
+
+import numpy as np
+import h5py
+
+from utils import download
+
+
+base_url = 'http://geant4.cern.ch/support/source/'
+filename = 'G4EMLOW.6.48.tar.gz'
+
+# ==============================================================================
+# DOWNLOAD FILES FROM GEANT4 SITE
+
+download(base_url + filename)
+
+# ==============================================================================
+# EXTRACT FILES FROM TGZ
+
+if not os.path.isdir('G4EMLOW6.48'):
+    with tarfile.open(filename, 'r') as tgz:
+        print('Extracting {}...'.format(filename))
+        tgz.extractall()
+
+# ==============================================================================
+# GENERATE COMPTON PROFILE HDF5 FILE
+
+print('Generating compton_profiles.h5...')
+
+shell_file = os.path.join('G4EMLOW6.48', 'doppler', 'shell-doppler.dat')
+
+with open(shell_file, 'r') as shell, h5py.File('compton_profiles.h5', 'w') as f:
+    # Read/write electron momentum values
+    pz = np.loadtxt(os.path.join('G4EMLOW6.48', 'doppler', 'p-biggs.dat'))
+    f.create_dataset('pz', data=pz)
+
+    for z in range(1, 101):
+        # Create group for this element
+        group = f.create_group('{:03}'.format(z))
+
+        # Read data into one long array
+        path = os.path.join('G4EMLOW6.48', 'doppler', 'profile-{}.dat'.format(z))
+        with open(path, 'r') as profile:
+            j = np.fromstring(profile.read(), sep=' ')
+
+        # Determine number of electron shells and reshape. Profiles are
+        # tabulated against a grid of 31 momentum values.
+        n_shells = j.size // 31
+        j.shape = (n_shells, 31)
+
+        # Write Compton profile for this Z
+        group.create_dataset('J', data=j)
+
+        # Determine binding energies and number of electrons for each shell
+        num_electrons = []
+        binding_energy = []
+        while True:
+            words = shell.readline().split()
+            if words[0] == '-1':
+                break
+            num_electrons.append(float(words[0]))
+            binding_energy.append(float(words[1]))
+
+        # Write binding energies and number of electrons
+        group.create_dataset('num_electrons', data=num_electrons)
+        group.create_dataset('binding_energy', data=binding_energy)

--- a/make_stopping_powers.py
+++ b/make_stopping_powers.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+
+from urllib.parse import urlencode
+from urllib.request import urlopen
+from lxml import html
+
+import numpy as np
+import h5py
+from openmc.data import ATOMIC_SYMBOL
+
+
+base_url = 'https://physics.nist.gov/cgi-bin/Star/e_table-t.pl'
+energies = np.logspace(-3, 3, 200)
+data = {'matno': '', 'Energies': '\n'.join(str(x) for x in energies)}
+columns = {1: 's_collision', 2: 's_radiative'}
+
+# ==============================================================================
+# SCRAPE DATA FROM ESTAR SITE AND GENERATE STOPPING POWER HDF5 FILE
+
+print('Generating stopping_powers.h5...')
+
+with h5py.File('stopping_powers.h5', 'w') as f:
+
+    # Write energies
+    f.create_dataset('energy', data=energies)
+
+    # Look over atomic number; ESTAR only goes up to Z=98 (Californium)
+    for Z in range(1, 99):
+        print('Processing {} data...'.format(ATOMIC_SYMBOL[Z]))
+
+        # Update form-encoded data to send in POST request for this element
+        data['matno'] = '{:03}'.format(Z)
+        payload = urlencode(data).encode("utf-8")
+
+        # Retrieve data from ESTAR site
+        with urlopen(url=base_url, data=payload) as response:
+            r = response.read()
+
+        # Remove text and reformat data -- omit first 12 and last 5 lines to get
+        # only data in table
+        r = html.fromstring(r).xpath('//pre//text()')
+        values = np.fromstring(' '.join(r[12:-5]), sep=' ').reshape((-1, 5)).T
+
+        # Create group for this element
+        group = f.create_group('{:03}'.format(Z))
+
+        # Write the mean excitation energy
+        attributes = np.fromstring(r[3], sep=' ')
+        group.attrs['I'] = attributes[2]
+
+        # Write collision and radiative stopping powers
+        for i in columns:
+            group.create_dataset(columns[i], data=values[i])

--- a/make_stopping_powers.py
+++ b/make_stopping_powers.py
@@ -29,7 +29,7 @@ with h5py.File('stopping_powers.h5', 'w') as f:
         print('Processing {} data...'.format(ATOMIC_SYMBOL[Z]))
 
         # Update form-encoded data to send in POST request for this element
-        data['matno'] = '{:03}'.format(Z)
+        data['matno'] = f'{Z:03}'
         payload = urlencode(data).encode("utf-8")
 
         # Retrieve data from ESTAR site
@@ -42,7 +42,7 @@ with h5py.File('stopping_powers.h5', 'w') as f:
         values = np.fromstring(' '.join(r[12:-5]), sep=' ').reshape((-1, 5)).T
 
         # Create group for this element
-        group = f.create_group('{:03}'.format(Z))
+        group = f.create_group(f'{Z:03}')
 
         # Write the mean excitation energy
         attributes = np.fromstring(r[3], sep=' ')


### PR DESCRIPTION
There were two scripts related to data generation that still lived in the main openmc repository. This PR simply moves them here and updates them to use pathlib consistently. Also, LANL just released an updated S(a,b) library for ENDF/B-VIII.0, so I've incorporated that into the convert_lib80x.py script.