### PR TITLE
Fix potential bug in decay energy calculation

### DIFF
--- a/depletion/generate_endf71_chain_casl.py
+++ b/depletion/generate_endf71_chain_casl.py
@@ -136,8 +136,7 @@ def main():
         if not CASL_CHAIN[parent][0] and \
            not data.nuclide['stable'] and data.half_life.nominal_value != 0.0:
             nuclide.half_life = data.half_life.nominal_value
-            nuclide.decay_energy = sum(E.nominal_value for E in
-                                       data.average_energies.values())
+            nuclide.decay_energy = data.decay_energy.nominal_value
             sum_br = 0.0
             for mode in data.modes:
                 decay_type = ','.join(mode.modes)


### PR DESCRIPTION
This is a companion PR to openmc-dev/openmc#1679. Some of the same logic for calculating decay energy appeared in the CASL chain generation script. There is actually no error in the CASL (or ENDF/B-VII.1 chains) because none of the decay sublibrary files from ENDF/B-VII.1 are affected by the original bug (openmc-dev/openmc#1672).