### PR TITLE
Adding tables to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ https://openmc.mcs.anl.gov.
 
 
 
-|       |                      | Download from [ openmc.mcs.anl.gov/ ] ( https://openmc.mcs.anl.gov/ ) | Download ACE files and convert HDF5 | Download ENDF files and generate HDF5 | Convert local files |
+|       |                      | Download from [openmc.mcs.anl.gov](https://openmc.mcs.anl.gov/)       | Download ACE files and convert HDF5 | Download ENDF files and generate HDF5 | Convert local files |
 |-------|----------------------|-----------------------------------------------------------------------|-------------------------------------|---------------------------------------|---------------------|
 | CENDL | 3.1                  |                                                                       |                                     | generate_cendl.py                     |                     |
 | ENDF  | B-VII.1              | :heavy_check_mark:                                                    | convert_nndc71.py                   | generate_endf71.py                    |                     |

--- a/README.md
+++ b/README.md
@@ -6,3 +6,15 @@ ACE libraries (such as those produced by LANL) whereas generate scripts use NJOY
 process ENDF files directly. Note that unless you are interested in making a
 customized library, you can find pregenerated HDF5 libraries at
 https://openmc.mcs.anl.gov.
+
+|       |                      | Download HDF5 from https://openmc.mcs.anl.gov/ | Download ACE files and convert HDF5 | Download ENDF files and generate HDF5 | Convert local files |
+|-------|----------------------|------------------------------------------------|-------------------------------------|---------------------------------------|---------------------|
+| CENDL | 3.1                  | :*:\cross::                                    |                                     | generate_cendl.py                     |                     |
+| ENDF  | B-VII.1              | :*:\check::                                    | convert_nndc71.py                   | generate_endf71.py                    |                     |
+| EDNF  | B-VII.0              | :*:\check::                                    |                                     | generate_endf80.py                    |                     |
+| FENDL | 2.1, 3.0, 3.1a, 3.1d | :*:\cross::                                    | convert_fendl.py                    |                                       |                     |
+| JEFF  | 3.2                  | :*:\check::                                    | convert_jeff32.py                   |                                       |                     |
+| JEFF  | 3.3                  | :*:\check::                                    | convert_jeff33.py                   |                                       |                     |
+| MCNP  | 70                   | :*:\check::                                    |                                     |                                       | convert_mcnp70.py   |
+| MCNP  | 71                   | :*:\check::                                    |                                     |                                       | convert_mcnp71.py   |
+| MCNP  | 80x                  | :*:\check::                                    |                                     |                                       | convert_lib80x.py   |

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ temperature.
 | Library | Release | Processed by | Download from [openmc.org](https://openmc.org/) | Download ACE files and convert HDF5 | Download ENDF files and generate HDF5 | Convert local ACE files |
 |-|-|-|-|-|-|-|
 | CENDL | 3.1 |  |  |  | generate_cendl.py |  |
-| ENDF | B-VII.0 | LANL | :heavy_check_mark: |  |  | convert_mcnp70.py |
-| ENDF | B-VII.1 | LANL | :heavy_check_mark: |  |  | convert_mcnp71.py |
-| ENDF | B-VII.1 | NNDC | :heavy_check_mark: | convert_nndc71.py | generate_endf71.py |  |
-| ENDF | B-VIII.0 | LANL | :heavy_check_mark: |  |  | convert_lib80x.py |
-| ENDF | B-VIII.0 | NNDC | :heavy_check_mark: |  | generate_endf80.py |  |
+| ENDF/B | VII.0 | LANL | :heavy_check_mark: |  |  | convert_mcnp70.py |
+| ENDF/B | VII.1 | LANL | :heavy_check_mark: |  |  | convert_mcnp71.py |
+| ENDF/B | VII.1 | NNDC | :heavy_check_mark: | convert_nndc71.py | generate_endf71.py |  |
+| ENDF/B | VIII.0 | LANL | :heavy_check_mark: |  |  | convert_lib80x.py |
+| ENDF/B | VIII.0 | NNDC | :heavy_check_mark: |  | generate_endf80.py |  |
 | FENDL | 2.1 3.0 3.1a 3.1d |  |  | convert_fendl.py |  |  |
 | JENDL | 4.0 |  |  |  | generate_jendl.py |  |
 | JEFF | 3.2 |  | :heavy_check_mark: | convert_jeff32.py |  |  |

--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ https://openmc.mcs.anl.gov.
 
 |       |                      | Download HDF5 from https://openmc.mcs.anl.gov/ | Download ACE files and convert HDF5 | Download ENDF files and generate HDF5 | Convert local files |
 |-------|----------------------|------------------------------------------------|-------------------------------------|---------------------------------------|---------------------|
-| CENDL | 3.1                  | [ ]                                            |                                     | generate_cendl.py                     |                     |
-| ENDF  | B-VII.1              | [x]                                            | convert_nndc71.py                   | generate_endf71.py                    |                     |
-| EDNF  | B-VII.0              | [x]                                            |                                     | generate_endf80.py                    |                     |
-| FENDL | 2.1, 3.0, 3.1a, 3.1d | [ ]                                            | convert_fendl.py                    |                                       |                     |
-| JEFF  | 3.2                  | [x]                                            | convert_jeff32.py                   |                                       |                     |
-| JEFF  | 3.3                  | [x]                                            | convert_jeff33.py                   |                                       |                     |
-| MCNP  | 70                   | [x]                                            |                                     |                                       | convert_mcnp70.py   |
-| MCNP  | 71                   | [x]                                            |                                     |                                       | convert_mcnp71.py   |
-| MCNP  | 80x                  | [x]                                            |                                     |                                       | convert_lib80x.py   |
+| CENDL | 3.1                  |                                                |                                     | generate_cendl.py                     |                     |
+| ENDF  | B-VII.1              | :heavy_check_mark:                             | convert_nndc71.py                   | generate_endf71.py                    |                     |
+| EDNF  | B-VII.0              | :heavy_check_mark:                             |                                     | generate_endf80.py                    |                     |
+| FENDL | 2.1, 3.0, 3.1a, 3.1d |                                                | convert_fendl.py                    |                                       |                     |
+| JEFF  | 3.2                  | :heavy_check_mark:                             | convert_jeff32.py                   |                                       |                     |
+| JEFF  | 3.3                  | :heavy_check_mark:                             | convert_jeff33.py                   |                                       |                     |
+| MCNP  | 70                   | :heavy_check_mark:                             |                                     |                                       | convert_mcnp70.py   |
+| MCNP  | 71                   | :heavy_check_mark:                             |                                     |                                       | convert_mcnp71.py   |
+| MCNP  | 80x                  | :heavy_check_mark:                             |                                     |                                       | convert_lib80x.py   |

--- a/README.md
+++ b/README.md
@@ -8,15 +8,14 @@ customized library, you can find pregenerated HDF5 libraries at
 https://openmc.mcs.anl.gov.
 
 
-
-|       |                      | Download from [openmc.mcs.anl.gov](https://openmc.mcs.anl.gov/)       | Download ACE files and convert HDF5 | Download ENDF files and generate HDF5 | Convert local files |
-|-------|----------------------|-----------------------------------------------------------------------|-------------------------------------|---------------------------------------|---------------------|
-| CENDL | 3.1                  |                                                                       |                                     | generate_cendl.py                     |                     |
-| ENDF  | B-VII.1              | :heavy_check_mark:                                                    | convert_nndc71.py                   | generate_endf71.py                    |                     |
-| EDNF  | B-VII.0              | :heavy_check_mark:                                                    |                                     | generate_endf80.py                    |                     |
-| FENDL | 2.1, 3.0, 3.1a, 3.1d |                                                                       | convert_fendl.py                    |                                       |                     |
-| JEFF  | 3.2                  | :heavy_check_mark:                                                    | convert_jeff32.py                   |                                       |                     |
-| JEFF  | 3.3                  | :heavy_check_mark:                                                    | convert_jeff33.py                   |                                       |                     |
-| MCNP  | 70                   | :heavy_check_mark:                                                    |                                     |                                       | convert_mcnp70.py   |
-| MCNP  | 71                   | :heavy_check_mark:                                                    |                                     |                                       | convert_mcnp71.py   |
-| MCNP  | 80x                  | :heavy_check_mark:                                                    |                                     |                                       | convert_lib80x.py   |
+| Library | Release | Download from [openmc.mcs.anl.gov](https://openmc.mcs.anl.gov/) | Download ACE files and convert HDF5 | Download ENDF files and generate HDF5 | Convert local ACE files |
+|-|-|:-:|:-:|:-:|:-:|
+| CENDL | 3.1 |  |  | generate_cendl.py |  |
+| ENDF | B-VII.1 | :heavy_check_mark: | convert_nndc71.py | generate_endf71.py |  |
+| ENDF | B-VII.0 | :heavy_check_mark: |  | generate_endf80.py |  |
+| FENDL | 2.1 3.0 3.1a 3.1d |  | convert_fendl.py |  |  |
+| JEFF | 3.2 | :heavy_check_mark: | convert_jeff32.py |  |  |
+| JEFF | 3.3 | :heavy_check_mark: | convert_jeff33.py |  |  |
+| MCNP | 70 | :heavy_check_mark: |  |  | convert_mcnp70.py |
+| MCNP | 71 | :heavy_check_mark: |  |  | convert_mcnp71.py |
+| MCNP | 80x | :heavy_check_mark: |  |  | convert_lib80x.py |

--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ https://openmc.mcs.anl.gov.
 
 |       |                      | Download HDF5 from https://openmc.mcs.anl.gov/ | Download ACE files and convert HDF5 | Download ENDF files and generate HDF5 | Convert local files |
 |-------|----------------------|------------------------------------------------|-------------------------------------|---------------------------------------|---------------------|
-| CENDL | 3.1                  | :*:\cross::                                    |                                     | generate_cendl.py                     |                     |
-| ENDF  | B-VII.1              | :*:\check::                                    | convert_nndc71.py                   | generate_endf71.py                    |                     |
-| EDNF  | B-VII.0              | :*:\check::                                    |                                     | generate_endf80.py                    |                     |
-| FENDL | 2.1, 3.0, 3.1a, 3.1d | :*:\cross::                                    | convert_fendl.py                    |                                       |                     |
-| JEFF  | 3.2                  | :*:\check::                                    | convert_jeff32.py                   |                                       |                     |
-| JEFF  | 3.3                  | :*:\check::                                    | convert_jeff33.py                   |                                       |                     |
-| MCNP  | 70                   | :*:\check::                                    |                                     |                                       | convert_mcnp70.py   |
-| MCNP  | 71                   | :*:\check::                                    |                                     |                                       | convert_mcnp71.py   |
-| MCNP  | 80x                  | :*:\check::                                    |                                     |                                       | convert_lib80x.py   |
+| CENDL | 3.1                  | [ ]                                            |                                     | generate_cendl.py                     |                     |
+| ENDF  | B-VII.1              | [x]                                            | convert_nndc71.py                   | generate_endf71.py                    |                     |
+| EDNF  | B-VII.0              | [x]                                            |                                     | generate_endf80.py                    |                     |
+| FENDL | 2.1, 3.0, 3.1a, 3.1d | [ ]                                            | convert_fendl.py                    |                                       |                     |
+| JEFF  | 3.2                  | [x]                                            | convert_jeff32.py                   |                                       |                     |
+| JEFF  | 3.3                  | [x]                                            | convert_jeff33.py                   |                                       |                     |
+| MCNP  | 70                   | [x]                                            |                                     |                                       | convert_mcnp70.py   |
+| MCNP  | 71                   | [x]                                            |                                     |                                       | convert_mcnp71.py   |
+| MCNP  | 80x                  | [x]                                            |                                     |                                       | convert_lib80x.py   |

--- a/README.md
+++ b/README.md
@@ -8,16 +8,16 @@ customized library, you can find pregenerated HDF5 libraries at
 https://openmc.mcs.anl.gov.
 
 
-| Library | Release | Download from [openmc.org](https://openmc.org/) | Download ACE files and convert HDF5 | Download ENDF files and generate HDF5 | Convert local ACE files |
-|-|-|:-:|:-:|:-:|:-:|
-| CENDL | 3.1 |  |  | generate_cendl.py |  |
-| ENDF | B-VII.1 | :heavy_check_mark: | convert_nndc71.py | generate_endf71.py |  |
-| ENDF | B-VII.0 | :heavy_check_mark: |  | generate_endf80.py |  |
-| FENDL | 2.1 3.0 3.1a 3.1d |  | convert_fendl.py |  |  |
-| JENDL | 4.0 |  |  | generate_jendl.py |  |
-| JEFF | 3.2 | :heavy_check_mark: | convert_jeff32.py |  |  |
-| JEFF | 3.3 | :heavy_check_mark: | convert_jeff33.py |  |  |
-| MCNP | 70 | :heavy_check_mark: |  |  | convert_mcnp70.py |
-| MCNP | 71 | :heavy_check_mark: |  |  | convert_mcnp71.py |
-| MCNP | 80x | :heavy_check_mark: |  |  | convert_lib80x.py |
-| TENDL | 2015 2017 2019 |  | convert_tendl.py |  |  |
+| Library | Release | Processed by | Download from [openmc.org](https://openmc.org/) | Download ACE files and convert HDF5 | Download ENDF files and generate HDF5 | Convert local ACE files |
+|-|-|-|-|-|-|-|
+| CENDL | 3.1 |  |  |  | generate_cendl.py |  |
+| ENDF | B-VII.0 | LANL | :heavy_check_mark: |  |  | convert_mcnp70.py |
+| ENDF | B-VII.1 | LANL | :heavy_check_mark: |  |  | convert_mcnp71.py |
+| ENDF | B-VII.1 | NNDC | :heavy_check_mark: | convert_nndc71.py | generate_endf71.py |  |
+| ENDF | B-VIII.0 | LANL | :heavy_check_mark: |  |  | convert_lib80x.py |
+| ENDF | B-VIII.0 | NNDC | :heavy_check_mark: |  | generate_endf80.py |  |
+| FENDL | 2.1 3.0 3.1a 3.1d |  |  | convert_fendl.py |  |  |
+| JENDL | 4.0 |  |  |  | generate_jendl.py |  |
+| JEFF | 3.2 |  | :heavy_check_mark: | convert_jeff32.py |  |  |
+| JEFF | 3.3 |  | :heavy_check_mark: | convert_jeff33.py |  |  |
+| TENDL | 2015 2017 2019 |  |  | convert_tendl.py |  |  |

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ libraries that can be used with OpenMC. Some of these scripts convert existing
 ACE libraries (such as those produced by LANL) whereas generate scripts use
 NJOY to process ENDF files directly. Note that unless you are interested in
 making a customized library, you can find pregenerated HDF5 libraries at
-https://openmc.mcs.anl.gov. Another source of data libraries for OpenMC is the
+https://openmc.org. Another source of data libraries for OpenMC is the
 [Windowed Multipole Library](https://github.com/mit-crpg/WMP_Library)
-repository which allows on-the-fly Doppler broadening to an arbitrary
+repository which enables on-the-fly Doppler broadening to an arbitrary
 temperature.
 
 | Library | Release | Processed by | Download from [openmc.org](https://openmc.org/) | Download ACE files and convert HDF5 | Download ENDF files and generate HDF5 | Convert local ACE files |

--- a/README.md
+++ b/README.md
@@ -7,14 +7,16 @@ process ENDF files directly. Note that unless you are interested in making a
 customized library, you can find pregenerated HDF5 libraries at
 https://openmc.mcs.anl.gov.
 
-|       |                      | Download HDF5 from https://openmc.mcs.anl.gov/ | Download ACE files and convert HDF5 | Download ENDF files and generate HDF5 | Convert local files |
-|-------|----------------------|------------------------------------------------|-------------------------------------|---------------------------------------|---------------------|
-| CENDL | 3.1                  |                                                |                                     | generate_cendl.py                     |                     |
-| ENDF  | B-VII.1              | :heavy_check_mark:                             | convert_nndc71.py                   | generate_endf71.py                    |                     |
-| EDNF  | B-VII.0              | :heavy_check_mark:                             |                                     | generate_endf80.py                    |                     |
-| FENDL | 2.1, 3.0, 3.1a, 3.1d |                                                | convert_fendl.py                    |                                       |                     |
-| JEFF  | 3.2                  | :heavy_check_mark:                             | convert_jeff32.py                   |                                       |                     |
-| JEFF  | 3.3                  | :heavy_check_mark:                             | convert_jeff33.py                   |                                       |                     |
-| MCNP  | 70                   | :heavy_check_mark:                             |                                     |                                       | convert_mcnp70.py   |
-| MCNP  | 71                   | :heavy_check_mark:                             |                                     |                                       | convert_mcnp71.py   |
-| MCNP  | 80x                  | :heavy_check_mark:                             |                                     |                                       | convert_lib80x.py   |
+
+
+|       |                      | Download from [ openmc.mcs.anl.gov/ ] ( https://openmc.mcs.anl.gov/ ) | Download ACE files and convert HDF5 | Download ENDF files and generate HDF5 | Convert local files |
+|-------|----------------------|-----------------------------------------------------------------------|-------------------------------------|---------------------------------------|---------------------|
+| CENDL | 3.1                  |                                                                       |                                     | generate_cendl.py                     |                     |
+| ENDF  | B-VII.1              | :heavy_check_mark:                                                    | convert_nndc71.py                   | generate_endf71.py                    |                     |
+| EDNF  | B-VII.0              | :heavy_check_mark:                                                    |                                     | generate_endf80.py                    |                     |
+| FENDL | 2.1, 3.0, 3.1a, 3.1d |                                                                       | convert_fendl.py                    |                                       |                     |
+| JEFF  | 3.2                  | :heavy_check_mark:                                                    | convert_jeff32.py                   |                                       |                     |
+| JEFF  | 3.3                  | :heavy_check_mark:                                                    | convert_jeff33.py                   |                                       |                     |
+| MCNP  | 70                   | :heavy_check_mark:                                                    |                                     |                                       | convert_mcnp70.py   |
+| MCNP  | 71                   | :heavy_check_mark:                                                    |                                     |                                       | convert_mcnp71.py   |
+| MCNP  | 80x                  | :heavy_check_mark:                                                    |                                     |                                       | convert_lib80x.py   |

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ customized library, you can find pregenerated HDF5 libraries at
 https://openmc.mcs.anl.gov.
 
 
-| Library | Release | Download from [openmc.mcs.anl.gov](https://openmc.mcs.anl.gov/) | Download ACE files and convert HDF5 | Download ENDF files and generate HDF5 | Convert local ACE files |
+| Library | Release | Download from [openmc.org](https://openmc.org/) | Download ACE files and convert HDF5 | Download ENDF files and generate HDF5 | Convert local ACE files |
 |-|-|:-:|:-:|:-:|:-:|
 | CENDL | 3.1 |  |  | generate_cendl.py |  |
 | ENDF | B-VII.1 | :heavy_check_mark: | convert_nndc71.py | generate_endf71.py |  |

--- a/README.md
+++ b/README.md
@@ -2,11 +2,13 @@
 
 This repository contains a collection of scripts for generating HDF5 data
 libraries that can be used with OpenMC. Some of these scripts convert existing
-ACE libraries (such as those produced by LANL) whereas generate scripts use NJOY to
-process ENDF files directly. Note that unless you are interested in making a
-customized library, you can find pregenerated HDF5 libraries at
-https://openmc.mcs.anl.gov.
-
+ACE libraries (such as those produced by LANL) whereas generate scripts use
+NJOY to process ENDF files directly. Note that unless you are interested in
+making a customized library, you can find pregenerated HDF5 libraries at
+https://openmc.mcs.anl.gov. Another source of data libraries for OpenMC is the
+[Windowed Multipole Library](https://github.com/mit-crpg/WMP_Library)
+repository which allows on-the-fly Doppler broadening to an arbitrary
+temperature.
 
 | Library | Release | Processed by | Download from [openmc.org](https://openmc.org/) | Download ACE files and convert HDF5 | Download ENDF files and generate HDF5 | Convert local ACE files |
 |-|-|-|-|-|-|-|

--- a/README.md
+++ b/README.md
@@ -14,8 +14,10 @@ https://openmc.mcs.anl.gov.
 | ENDF | B-VII.1 | :heavy_check_mark: | convert_nndc71.py | generate_endf71.py |  |
 | ENDF | B-VII.0 | :heavy_check_mark: |  | generate_endf80.py |  |
 | FENDL | 2.1 3.0 3.1a 3.1d |  | convert_fendl.py |  |  |
+| JENDL | 4.0 |  |  | generate_jendl.py |  |
 | JEFF | 3.2 | :heavy_check_mark: | convert_jeff32.py |  |  |
 | JEFF | 3.3 | :heavy_check_mark: | convert_jeff33.py |  |  |
 | MCNP | 70 | :heavy_check_mark: |  |  | convert_mcnp70.py |
 | MCNP | 71 | :heavy_check_mark: |  |  | convert_mcnp71.py |
 | MCNP | 80x | :heavy_check_mark: |  |  | convert_lib80x.py |
+| TENDL | 2015 2017 2019 |  | convert_tendl.py |  |  |


### PR DESCRIPTION
Just adding a little table to the readme as a guide that shows what we have covered and the different options for downloading

Also I noticed the https://openmc.mcs.anl.gov/ website as two scripts for JEFF 3.3, just wondering if there is a difference

probably best to go here to see the rendered table https://github.com/openmc-dev/data/tree/adding_tables_to_readme
