### PR TITLE
Fixes small bug in sample_sandy.py and add small feature

### DIFF
--- a/convert_tendl_rand.py
+++ b/convert_tendl_rand.py
@@ -45,8 +45,10 @@ parser = argparse.ArgumentParser(
 parser.add_argument("-n", "--nuclides", choices=n_choices, nargs="+",
                     default=["Fe56"], help="The nuclides to be downloaded. Available are: "
                     "'O16','Si28', 'Si29','Si30', 'Fe54', 'Fe56', 'Fe57', 'Fe58', 'Na23', 'Pu240'. Use 'all' for all availiable")
-parser.add_argument( "-d", "--destination", default=None, 
+parser.add_argument("-d", "--destination", default=None, 
                     help="Directory to create new library in")
+parser.add_argument("-x", "--xlib", default=None, 
+                    help="cross_section.xml library to add random evaluations to")
 parser.add_argument("-b", "--batch", action="store_true", 
                     help="supresses standard in")
 parser.add_argument("-f", "--format_only", default=False,
@@ -79,6 +81,11 @@ if args.destination is None:
 else:
     output_dir = Path(args.destination).resolve()
 
+xslib = args.xslib
+if xslib == None:
+    xslib = os.getenv("OPENMC_CROSS_SECTIONS")
+else:
+    xslib = Path(xslib).resolve()
 
 endf_files_dir = output_dir / "endf"
 ace_files_dir = output_dir / "ace"
@@ -333,7 +340,7 @@ with Pool() as pool:
 # Create xml library
 
 lib = openmc.data.DataLibrary()
-lib = lib.from_xml(os.getenv("OPENMC_CROSS_SECTIONS"))  # Gets current
+lib = lib.from_xml(xslib)  # Gets current
 
 for nuc in nuclides:
     file_num = nuclide_details[nuc]["file_num"]

--- a/convert_tendl_rand.py
+++ b/convert_tendl_rand.py
@@ -81,11 +81,11 @@ if args.destination is None:
 else:
     output_dir = Path(args.destination).resolve()
 
-xslib = args.xslib
-if xslib == None:
-    xslib = os.getenv("OPENMC_CROSS_SECTIONS")
+xlib = args.xlib
+if xlib == None:
+    xlib = os.getenv("OPENMC_CROSS_SECTIONS")
 else:
-    xslib = Path(xslib).resolve()
+    xlib = Path(xlib).resolve()
 
 endf_files_dir = output_dir / "endf"
 ace_files_dir = output_dir / "ace"
@@ -340,7 +340,7 @@ with Pool() as pool:
 # Create xml library
 
 lib = openmc.data.DataLibrary()
-lib = lib.from_xml(xslib)  # Gets current
+lib = lib.from_xml(xlib)  # Gets current
 
 for nuc in nuclides:
     file_num = nuclide_details[nuc]["file_num"]

--- a/sample_sandy.py
+++ b/sample_sandy.py
@@ -62,11 +62,11 @@ if libdir == None:
 else:
     libdir = Path(libdir).resolve()
 
-xslib = args.xslib
-if xslib == None:
-    xslib = os.getenv("OPENMC_CROSS_SECTIONS")
+xlib = args.xlib
+if xlib == None:
+    xlib = os.getenv("OPENMC_CROSS_SECTIONS")
 else:
-    xslib = Path(xslib).resolve()
+    xlib = Path(xlib).resolve()
 
 nuclides = args.nuclides
 
@@ -170,7 +170,7 @@ with Pool() as pool:
 # Create xml library
 
 lib = openmc.data.DataLibrary()
-lib = lib.from_xml(xslib)  # Gets current
+lib = lib.from_xml(xlib)  # Gets current
 
 for nuc in nuclides:
     out_dir = hdf5_files_dir / nuc

--- a/sample_sandy.py
+++ b/sample_sandy.py
@@ -183,7 +183,7 @@ post = output_dir / "cross_sections_sandy.xml"
 
 lib.export_to_xml(pre)
 if post.exists():
-    command = f"python combine_libraries.py -l {pre} {post} -o {post}"
+    command = f"combine_libraries.py -l {pre} {post} -o {post}"
     os.system(command)
 else:
     lib.export_to_xml(post)

--- a/sample_sandy.py
+++ b/sample_sandy.py
@@ -35,6 +35,8 @@ parser.add_argument("-d", "--destination", default=None,
                     help="Directory to create new library in")
 parser.add_argument("-l", "--libdir", default=None, 
                     help="Directory of endf library to sample eg. nndc-b7.1-endf folder")
+parser.add_argument("-x", "--xlib", default=None, 
+                    help="cross_section.xml library to add random evaluations to. Default is OPENMC_CROSS_SECTIONS")
 parser.add_argument("-s", "--samples", default=200, 
                     help="Number of samples per nuclide")
 parser.add_argument("-p", "--processes", default=1, 
@@ -59,6 +61,12 @@ if libdir == None:
     raise Exception("Directory of ENDF library required for sampling, eg. nndc-b7.1-endf folder. Use -l prefix to specify")
 else:
     libdir = Path(libdir).resolve()
+
+xslib = args.xslib
+if xslib == None:
+    xslib = os.getenv("OPENMC_CROSS_SECTIONS")
+else:
+    xslib = Path(xslib).resolve()
 
 nuclides = args.nuclides
 
@@ -162,7 +170,7 @@ with Pool() as pool:
 # Create xml library
 
 lib = openmc.data.DataLibrary()
-lib = lib.from_xml(os.getenv("OPENMC_CROSS_SECTIONS"))  # Gets current
+lib = lib.from_xml(xslib)  # Gets current
 
 for nuc in nuclides:
     out_dir = hdf5_files_dir / nuc


### PR DESCRIPTION
There is a small bug in `sample_sandy.py` (line 178).

Also allows the user to pass a `cross_sections.xml` file to which the random evaluations will be added.
Previously always `OPENMC_CROSS_SECTIONS` was imported. This is important because it is otherwise easy to mix random files from say TENDL with evaluations from another library. 

