### PR TITLE
Add CENDL-3.2 Library

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ temperature.
 | Library | Release | Processed by | Download from [openmc.org](https://openmc.org/) | Download ACE files and convert HDF5 | Download ENDF files and generate HDF5 | Convert local ACE files |
 |-|-|-|-|-|-|-|
 | CENDL | <p>3.1<br>3.2</p> |  |  |  | generate_cendl.py |  |
-| CENDL | <p>3.1<br>3.2</p> |  |  |  |  |  |
 | ENDF/B | VII.0 | LANL | :heavy_check_mark: |  |  | convert_mcnp70.py |
 | ENDF/B | VII.1 | LANL | :heavy_check_mark: |  |  | convert_mcnp71.py |
 | ENDF/B | VII.1 | NNDC | :heavy_check_mark: | convert_nndc71.py | generate_endf.py |  |

--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ temperature.
 
 | Library | Release | Processed by | Download from [openmc.org](https://openmc.org/) | Download ACE files and convert HDF5 | Download ENDF files and generate HDF5 | Convert local ACE files |
 |-|-|-|-|-|-|-|
-| CENDL | <p>3.1<br>3.2</p> |  |  |  | generate_cendl.py |  |
+| CENDL | 3.1<br>3.2 |  |  |  | generate_cendl.py |  |
 | ENDF/B | VII.0 | LANL | :heavy_check_mark: |  |  | convert_mcnp70.py |
 | ENDF/B | VII.1 | LANL | :heavy_check_mark: |  |  | convert_mcnp71.py |
 | ENDF/B | VII.1 | NNDC | :heavy_check_mark: | convert_nndc71.py | generate_endf.py |  |
 | ENDF/B | VIII.0 | LANL | :heavy_check_mark: |  |  | convert_lib80x.py |
 | ENDF/B | VIII.0 | NNDC | :heavy_check_mark: |  | generate_endf.py |  |
-| FENDL | 2.1 3.0 3.1a 3.1d |  |  | convert_fendl.py |  |  |
+| FENDL | 2.1<br>3.0<br>3.1a<br>3.1d |  |  | convert_fendl.py |  |  |
 | JENDL | 4.0 |  |  |  | generate_jendl.py |  |
 | JEFF | 3.2 |  | :heavy_check_mark: | convert_jeff32.py |  |  |
 | JEFF | 3.3 |  | :heavy_check_mark: | convert_jeff33.py |  |  |

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ temperature.
 
 | Library | Release | Processed by | Download from [openmc.org](https://openmc.org/) | Download ACE files and convert HDF5 | Download ENDF files and generate HDF5 | Convert local ACE files |
 |-|-|-|-|-|-|-|
-| CENDL | 3.1 3.2 |  |  |  | generate_cendl.py |  |
+| CENDL | <p>3.1<br>3.2</p> |  |  |  | generate_cendl.py |  |
+| CENDL | <p>3.1<br>3.2</p> |  |  |  |  |  |
 | ENDF/B | VII.0 | LANL | :heavy_check_mark: |  |  | convert_mcnp70.py |
 | ENDF/B | VII.1 | LANL | :heavy_check_mark: |  |  | convert_mcnp71.py |
 | ENDF/B | VII.1 | NNDC | :heavy_check_mark: | convert_nndc71.py | generate_endf.py |  |

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ temperature.
 
 | Library | Release | Processed by | Download from [openmc.org](https://openmc.org/) | Download ACE files and convert HDF5 | Download ENDF files and generate HDF5 | Convert local ACE files |
 |-|-|-|-|-|-|-|
-| CENDL | 3.1 |  |  |  | generate_cendl.py |  |
+| CENDL | 3.1 3.2 |  |  |  | generate_cendl.py |  |
 | ENDF/B | VII.0 | LANL | :heavy_check_mark: |  |  | convert_mcnp70.py |
 | ENDF/B | VII.1 | LANL | :heavy_check_mark: |  |  | convert_mcnp71.py |
 | ENDF/B | VII.1 | NNDC | :heavy_check_mark: | convert_nndc71.py | generate_endf.py |  |

--- a/generate_cendl.py
+++ b/generate_cendl.py
@@ -40,7 +40,7 @@ parser.add_argument('--libver', choices=['earliest', 'latest'],
                     "'earliest' for backwards compatibility or 'latest' for "
                     "performance")
 parser.add_argument('-r', '--release', choices=['3.1', '3.2'],
-                    default='3.1', help="The nuclear data library release "
+                    default='3.2', help="The nuclear data library release "
                     "version. The currently supported options are 3.1, 3.2")
 parser.add_argument('--cleanup', action='store_true',
                     help="Remove download directories when data has "

--- a/generate_cendl.py
+++ b/generate_cendl.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 
 """
-Download CENDL 3.1 data from OECD NEA and convert it to a HDF5 library for
-use with OpenMC.
+Download CENDL 3.1 data from OECD NEA or CENDL-3.2 from CNDC
+and convert it to a HDF5 library for use with OpenMC.
 """
 
 import argparse
@@ -39,9 +39,9 @@ parser.add_argument('--libver', choices=['earliest', 'latest'],
                     default='latest', help="Output HDF5 versioning. Use "
                     "'earliest' for backwards compatibility or 'latest' for "
                     "performance")
-parser.add_argument('-r', '--release', choices=['3.1'],
+parser.add_argument('-r', '--release', choices=['3.1', '3.2'],
                     default='3.1', help="The nuclear data library release "
-                    "version. The only option currently supported is 3.1")
+                    "version. The currently supported options are 3.1, 3.2")
 parser.add_argument('--cleanup', action='store_true',
                     help="Remove download directories when data has "
                     "been processed")
@@ -73,7 +73,15 @@ release_details = {
         'metastables': endf_files_dir.glob('*m.C31'),
         'compressed_file_size': '0.03 GB',
         'uncompressed_file_size': '0.4 GB'
-    }
+    },
+    '3.2': {
+       'base_url': 'http://www.nuclear.csdb.cn/endf/CENDL/',
+       'compressed_files': ['n-CENDL-3.2.zip'],
+       'neutron_files': endf_files_dir.glob('n-CENDL-3.2/CENDL-3.2/*.C32'),
+       'metastables': endf_files_dir.glob('n-CENDL-3.2/CENDL-3.2/*m.C32'),
+       'compressed_file_size': '0.11 GB',
+       'uncompressed_file_size': '0.41 GB'
+       }
 }
 
 download_warning = """


### PR DESCRIPTION
For zip file download, I've used [CNDC](http://www.nuclear.csdb.cn/cendl32.htm) web-link because OECD NEA didn't include it in their data bank but it's available from [IAEA-NDS](https://www-nds.iaea.org/public/download-endf/). 