### PR TITLE
changed fendl 3.1d to the new url

### DIFF
--- a/convert_fendl.py
+++ b/convert_fendl.py
@@ -126,7 +126,7 @@ release_details = {
     },
     '3.1d': {
         'neutron': {
-            'base_url': 'https://www-nds.iaea.org/fendl/data/neutron/',
+            'base_url': 'https://www-nds.iaea.org/fendl31d/data/neutron/',
             'compressed_files': ['fendl31d-neutron-ace.zip'],
             'file_type': 'ace',
             'ace_files': ace_files_dir.joinpath('fendl31d_ACE').glob('*'),
@@ -134,7 +134,7 @@ release_details = {
             'uncompressed_file_size': 2290
         },
         'photon': {
-            'base_url': 'https://www-nds.iaea.org/fendl/data/atom/',
+            'base_url': 'https://www-nds.iaea.org/fendl31d/data/atom/',
             'compressed_files': ['fendl30-atom-endf.zip'],
             'file_type': 'endf',
             'photo_files': endf_files_dir.joinpath('endf').glob('*.txt'),


### PR DESCRIPTION
It appears that the url we were using to download fendl 3.1d has moved.

I think this is because we were pointing to the latest fendl release url and now that version 3.2 has been released version 3.1d is no longer the latest.

So we can now grab that data from the archived urls and this PR is a small update to the url

I noticed this over on the CI for the new openmc-data-storage repository
https://github.com/openmc-data-storage/FENDL-3.1d/runs/2268201096?check_suite_focus=true