### PR TITLE
Remove Be7 from ENDF/B-VII.1 depletion chains

### DIFF
--- a/depletion/chain_endfb71_pwr.xml
+++ b/depletion/chain_endfb71_pwr.xml
@@ -28,7 +28,7 @@
   </nuclide>
   <nuclide name="He4" reactions="0"/>
   <nuclide name="He5" half_life="7.595e-22" decay_modes="1" decay_energy="890000.0" reactions="0">
-    <decay type="alpha" target="H1" branching_ratio="1.0"/>
+    <decay type="alpha" branching_ratio="1.0"/>
   </nuclide>
   <nuclide name="He6" half_life="0.8067" decay_modes="1" decay_energy="1567620.0" reactions="0">
     <decay type="beta-" target="Li6" branching_ratio="1.0"/>
@@ -81,11 +81,6 @@
   </nuclide>
   <nuclide name="Be6" half_life="4.95326e-21" decay_modes="1" decay_energy="1372000.0" reactions="0">
     <decay type="p,p" target="He4" branching_ratio="1.0"/>
-  </nuclide>
-  <nuclide name="Be7" half_life="4598208.0" decay_modes="1" decay_energy="49861.81" reactions="2">
-    <decay type="ec/beta+" target="Li7" branching_ratio="1.0"/>
-    <reaction type="(n,p)" Q="1644300.0" target="Li7"/>
-    <reaction type="(n,a)" Q="18992000.0" target="He4"/>
   </nuclide>
   <nuclide name="Be8" half_life="8.18132e-17" decay_modes="1" decay_energy="91840.0" reactions="0">
     <decay type="alpha" target="He4" branching_ratio="1.0"/>

--- a/depletion/chain_endfb71_sfr.xml
+++ b/depletion/chain_endfb71_sfr.xml
@@ -28,7 +28,7 @@
   </nuclide>
   <nuclide name="He4" reactions="0"/>
   <nuclide name="He5" half_life="7.595e-22" decay_modes="1" decay_energy="890000.0" reactions="0">
-    <decay type="alpha" target="H1" branching_ratio="1.0"/>
+    <decay type="alpha" branching_ratio="1.0"/>
   </nuclide>
   <nuclide name="He6" half_life="0.8067" decay_modes="1" decay_energy="1567620.0" reactions="0">
     <decay type="beta-" target="Li6" branching_ratio="1.0"/>
@@ -81,11 +81,6 @@
   </nuclide>
   <nuclide name="Be6" half_life="4.95326e-21" decay_modes="1" decay_energy="1372000.0" reactions="0">
     <decay type="p,p" target="He4" branching_ratio="1.0"/>
-  </nuclide>
-  <nuclide name="Be7" half_life="4598208.0" decay_modes="1" decay_energy="49861.81" reactions="2">
-    <decay type="ec/beta+" target="Li7" branching_ratio="1.0"/>
-    <reaction type="(n,p)" Q="1644300.0" target="Li7"/>
-    <reaction type="(n,a)" Q="18992000.0" target="He4"/>
   </nuclide>
   <nuclide name="Be8" half_life="8.18132e-17" decay_modes="1" decay_energy="91840.0" reactions="0">
     <decay type="alpha" target="He4" branching_ratio="1.0"/>

--- a/depletion/generate_endf71_chain.py
+++ b/depletion/generate_endf71_chain.py
@@ -29,9 +29,13 @@ def main():
                 zf.extractall()
         endf_dir = Path(".")
 
-    decay_files = tuple((endf_dir / "decay").glob("*endf"))
-    neutron_files = tuple((endf_dir / "neutrons").glob("*endf"))
-    nfy_files = tuple((endf_dir / "nfy").glob("*endf"))
+    decay_files = list((endf_dir / "decay").glob("*endf"))
+    neutron_files = list((endf_dir / "neutrons").glob("*endf"))
+    nfy_files = list((endf_dir / "nfy").glob("*endf"))
+
+    # Remove erroneous Be7 evaluation that can cause problems
+    decay_files.remove(endf_dir / "decay" / "dec-004_Be_007.endf")
+    neutron_files.remove(endf_dir / "neutrons" / "n-004_Be_007.endf")
 
     # check files exist
     for flist, ftype in [(decay_files, "decay"), (neutron_files, "neutron"),


### PR DESCRIPTION
A user [recently experienced problems](https://openmc.discourse.group/t/depletion-error-did-not-sample-any-reaction-for-nuclide-pb204/1362/3) trying to run a depletion simulation with the full ENDF/B-VII.1 depletion chain. It turns out the root cause of this problem was that the depletion chain results in Be7 getting added to depletable materials, and Be7 erroneously only has data up to ~8 MeV in ENDF/B-VII.1. Because the user's problem had neutrons > 10 MeV, this resulted in errors looking up cross sections. This PR manually removes Be7 from the ENDF/B-VII.1 depletion chains so that others don't run into this. Once it's merged, I'll update the data on openmc.org.

You'll also notice that an incorrect decay product from He5 was removed -- we had some logic in `Chain.from_endf` before that resulted in any neutron as a decay product getting turned into a proton (H1). That logic has been changed, so rerunning generate_endf71_chain.py now removes this wrong decay product. 