### PR TITLE
added tendl2021 fendl2.2 to readme table

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ temperature.
 | ENDF/B | VII.1 | NNDC | :heavy_check_mark: | convert_nndc71.py | generate_endf.py |  |
 | ENDF/B | VIII.0 | LANL | :heavy_check_mark: |  |  | convert_lib80x.py |
 | ENDF/B | VIII.0 | NNDC | :heavy_check_mark: |  | generate_endf.py |  |
-| FENDL | 2.1<br>3.0<br>3.1a<br>3.1d |  |  | convert_fendl.py |  |  |
+| FENDL | 2.1<br>3.0<br>3.1a<br>3.1d<br>3.2 |  |  | convert_fendl.py |  |  |
 | JENDL | 4.0 |  |  |  | generate_jendl.py |  |
 | JEFF | 3.2 |  | :heavy_check_mark: | convert_jeff32.py |  |  |
 | JEFF | 3.3 |  | :heavy_check_mark: | convert_jeff33.py |  |  |
-| TENDL | 2015 2017 2019 |  |  | convert_tendl.py |  |  |
+| TENDL | 2015<br>2017<br>2019<br>2021|  |  | convert_tendl.py |  |  |


### PR DESCRIPTION
I forgot to update the readme with the last to PR 

So this tiny PR adds the new versions of tendl and fendl to the readme table