### PR TITLE
update failing links to new urls

### DIFF
--- a/convert_nndc71.py
+++ b/convert_nndc71.py
@@ -69,7 +69,7 @@ download_path = cwd.joinpath('-'.join([library_name, release, 'download']))
 release_details = {
     'b7.1': {
         'neutron': {
-            'base_url': 'http://www.nndc.bnl.gov/endf/b7.1/aceFiles/',
+            'base_url': 'http://www.nndc.bnl.gov/endf-b7.1/aceFiles/',
             'compressed_files': ['ENDF-B-VII.1-neutron-293.6K.tar.gz',
                                  'ENDF-B-VII.1-tsl.tar.gz'],
             'checksums': ['9729a17eb62b75f285d8a7628ace1449',
@@ -81,7 +81,7 @@ release_details = {
             'uncompressed_file_size': 1200
         },
         'photon': {
-            'base_url': 'http://www.nndc.bnl.gov/endf/b7.1/zips/',
+            'base_url': 'http://www.nndc.bnl.gov/endf-b7.1/zips/',
             'compressed_files': ['ENDF-B-VII.1-photoat.zip',
                                  'ENDF-B-VII.1-atomic_relax.zip'],
             'checksums': ['5192f94e61f0b385cf536f448ffab4a4',

--- a/depletion/generate_endf71_chain.py
+++ b/depletion/generate_endf71_chain.py
@@ -10,9 +10,9 @@ from utils import download
 
 
 URLS = [
-    'https://www.nndc.bnl.gov/endf/b7.1/zips/ENDF-B-VII.1-neutrons.zip',
-    'https://www.nndc.bnl.gov/endf/b7.1/zips/ENDF-B-VII.1-decay.zip',
-    'https://www.nndc.bnl.gov/endf/b7.1/zips/ENDF-B-VII.1-nfy.zip'
+    'https://www.nndc.bnl.gov/endf-b7.1/zips/ENDF-B-VII.1-neutrons.zip',
+    'https://www.nndc.bnl.gov/endf-b7.1/zips/ENDF-B-VII.1-decay.zip',
+    'https://www.nndc.bnl.gov/endf-b7.1/zips/ENDF-B-VII.1-nfy.zip'
 ]
 
 def main():

--- a/depletion/generate_endf71_chain_casl.py
+++ b/depletion/generate_endf71_chain_casl.py
@@ -25,9 +25,9 @@ from casl_chain import CASL_CHAIN, UNMODIFIED_DECAY_BR
 from utils import download
 
 URLS = [
-    'https://www.nndc.bnl.gov/endf/b7.1/zips/ENDF-B-VII.1-neutrons.zip',
-    'https://www.nndc.bnl.gov/endf/b7.1/zips/ENDF-B-VII.1-decay.zip',
-    'https://www.nndc.bnl.gov/endf/b7.1/zips/ENDF-B-VII.1-nfy.zip'
+    'https://www.nndc.bnl.gov/endf-b7.1/zips/ENDF-B-VII.1-neutrons.zip',
+    'https://www.nndc.bnl.gov/endf-b7.1/zips/ENDF-B-VII.1-decay.zip',
+    'https://www.nndc.bnl.gov/endf-b7.1/zips/ENDF-B-VII.1-nfy.zip'
 ]
 
 

--- a/depletion/generate_tendl_chain.py
+++ b/depletion/generate_tendl_chain.py
@@ -23,11 +23,11 @@ from utils import download
 NEUTRON_LIB = 'https://tendl.web.psi.ch/tendl_2019/tar_files/TENDL-n.tgz'
 DECAY_LIB = {
     'jeff33': 'https://www.oecd-nea.org/dbdata/jeff/jeff33/downloads/JEFF33-rdd.zip',
-    'endf80': 'https://www.nndc.bnl.gov/endf/b8.0/zips/ENDF-B-VIII.0_decay.zip',
+    'endf80': 'https://www.nndc.bnl.gov/endf-b8.0/zips/ENDF-B-VIII.0_decay.zip',
 }
 NFY_LIB = {
     'jeff33': 'https://www.oecd-nea.org/dbdata/jeff/jeff33/downloads/JEFF33-nfy.asc',
-    'endf80': 'https://www.nndc.bnl.gov/endf/b8.0/zips/ENDF-B-VIII.0_nfy.zip',
+    'endf80': 'https://www.nndc.bnl.gov/endf-b8.0/zips/ENDF-B-VIII.0_nfy.zip',
 }
 
 

--- a/generate_endf.py
+++ b/generate_endf.py
@@ -93,7 +93,7 @@ if args.destination is None:
 release_details = {
     'vii.1': {
         'neutron': {
-            'base_url': 'http://www.nndc.bnl.gov/endf/b7.1/zips/',
+            'base_url': 'http://www.nndc.bnl.gov/endf-b7.1/zips/',
             'compressed_files': ['ENDF-B-VII.1-neutrons.zip',
                                  'ENDF-B-VII.1-thermal_scatt.zip'],
             'checksums': ['e5d7f441fc4c92893322c24d1725e29c',
@@ -127,7 +127,7 @@ release_details = {
             'uncompressed_file_size': 916
         },
         'photon': {
-            'base_url': 'http://www.nndc.bnl.gov/endf/b7.1/zips/',
+            'base_url': 'http://www.nndc.bnl.gov/endf-b7.1/zips/',
             'compressed_files': ['ENDF-B-VII.1-photoat.zip',
                                  'ENDF-B-VII.1-atomic_relax.zip'],
             'checksums': ['5192f94e61f0b385cf536f448ffab4a4',
@@ -148,7 +148,7 @@ release_details = {
     },
     'viii.0': {
         'neutron': {
-            'base_url': 'https://www.nndc.bnl.gov/endf/b8.0/',
+            'base_url': 'https://www.nndc.bnl.gov/endf-b8.0/',
             'compressed_files': ['zips/ENDF-B-VIII.0_neutrons.zip',
                                  'zips/ENDF-B-VIII.0_thermal_scatt.zip',
                                  'erratafiles/n-005_B_010.endf'],
@@ -197,7 +197,7 @@ release_details = {
             'uncompressed_file_size': 999999
         },
         'photon': {
-            'base_url': 'https://www.nndc.bnl.gov/endf/b8.0/',
+            'base_url': 'https://www.nndc.bnl.gov/endf-b8.0/',
             'compressed_files': ['zips/ENDF-B-VIII.0_photoat.zip',
                                  'erratafiles/atomic_relax.tar.gz'],
             'checksums': ['d49f5b54be278862e1ce742ccd94f5c0',

--- a/generate_jeff33.py
+++ b/generate_jeff33.py
@@ -69,7 +69,7 @@ def sort_key(path):
         return openmc.data.zam(path.stem)
 
 
-base_endf = 'https://www.nndc.bnl.gov/endf/b8.0/zips/'
+base_endf = 'https://www.nndc.bnl.gov/endf-b8.0/zips/'
 base_jeff = 'http://www.oecd-nea.org/dbdata/jeff/jeff33/downloads/'
 files = [
     (base_jeff, 'JEFF33-n.tgz', '88771640ab08f4dccce8e542fdf90062'),


### PR DESCRIPTION
I was just running the nice depletion/generate_endf71_chain.py script and got a 404 url not found error

so I went to the website and it looks like all the links have changed slightly.

I've been through and updated the links in a few places to get them working again

