### PR TITLE
added url test idea

### DIFF
--- a/.github/workflows/test_urls.yml
+++ b/.github/workflows/test_urls.yml
@@ -16,6 +16,17 @@ jobs:
     build:
       runs-on: ubuntu-latest
       steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
+      - name: Install testing dependencies
+        run: |
+          pip install pytest
+
       - name: test urls
         run: |
           pytest tests/tests_urls.py

--- a/.github/workflows/test_urls.yml
+++ b/.github/workflows/test_urls.yml
@@ -1,6 +1,7 @@
 
-name: auto_benchmark
+name: test_urls
 on:  
+  workflow_dispatch:
   pull_request:    
     branches:
     - main  

--- a/.github/workflows/test_urls.yml
+++ b/.github/workflows/test_urls.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Install testing dependencies
         run: |
           pip install pytest
+          pip install requests
 
       - name: test urls
         run: |

--- a/.github/workflows/test_urls.yml
+++ b/.github/workflows/test_urls.yml
@@ -1,0 +1,20 @@
+
+name: auto_benchmark
+on:  
+  pull_request:    
+    branches:
+    - main  
+  push:
+    branches:
+    - main
+  schedule:
+    - cron: "0 0 * * *"
+# cron job runs every day
+
+jobs:
+    build:
+      runs-on: ubuntu-latest
+      steps:
+      - name: test urls
+        run: |
+          pytest tests/tests_urls.py

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![test_urls](https://github.com/shimwell/data/actions/workflows/test_urls.yml/badge.svg)](https://github.com/shimwell/data/actions/workflows/test_urls.yml)
+
 # OpenMC Data Scripts
 
 This repository contains a collection of scripts for generating HDF5 data

--- a/convert_tendl.py
+++ b/convert_tendl.py
@@ -14,6 +14,7 @@ from urllib.parse import urljoin
 
 import openmc.data
 from utils import download
+from tests.urls import all_release_details
 
 # Make sure Python version is sufficient
 assert sys.version_info >= (3, 6), "Python 3.6+ is required"
@@ -68,40 +69,7 @@ if args.destination is None:
 
 # This dictionary contains all the unique information about each release.
 # This can be exstened to accommodated new releases
-release_details = {
-    '2015': {
-        'base_url': 'https://tendl.web.psi.ch/tendl_2015/tar_files/',
-        'compressed_files': ['ACE-n.tgz'],
-        'neutron_files': ace_files_dir.glob('neutron_file/*/*/lib/endf/*-n.ace'),
-        'metastables': ace_files_dir.glob('neutron_file/*/*/lib/endf/*m-n.ace'),
-        'compressed_file_size': '5.1 GB',
-        'uncompressed_file_size': '40 GB'
-    },
-    '2017': {
-        'base_url': 'https://tendl.web.psi.ch/tendl_2017/tar_files/',
-        'compressed_files': ['tendl17c.tar.bz2'],
-        'neutron_files': ace_files_dir.glob('ace-17/*'),
-        'metastables': ace_files_dir.glob('ace-17/*m'),
-        'compressed_file_size': '2.1 GB',
-        'uncompressed_file_size': '14 GB'
-    },
-    '2019': {
-        'base_url': 'https://tendl.web.psi.ch/tendl_2019/tar_files/',
-        'compressed_files': ['tendl19c.tar.bz2'],
-        'neutron_files': ace_files_dir.glob('tendl19c/*'),
-        'metastables': ace_files_dir.glob('tendl19c/*m'),
-        'compressed_file_size': '2.3 GB',
-        'uncompressed_file_size': '10.1 GB'
-    },
-    '2021': {
-        'base_url': 'https://tendl.web.psi.ch/tendl_2021/tar_files/',
-        'compressed_files': ['tendl21c.tar.bz2'],
-        'neutron_files': ace_files_dir.glob('tendl21c/*'),
-        'metastables': ace_files_dir.glob('tendl21c/*m'),
-        'compressed_file_size': '2.2 GB',
-        'uncompressed_file_size': '10.5 GB'
-    }
-}
+release_details = all_release_details[library_name]
 
 download_warning = """
 WARNING: This script will download {} of data.
@@ -134,7 +102,7 @@ if args.extract:
 # ==============================================================================
 # CHANGE ZAID FOR METASTABLES
 
-metastables = release_details[args.release]['metastables']
+metastables = ace_files_dir.glob(release_details[args.release]['metastables'])
 for path in metastables:
     print('    Fixing {} (ensure metastable)...'.format(path))
     text = open(path, 'r').read()
@@ -147,7 +115,7 @@ for path in metastables:
 # GENERATE HDF5 LIBRARY -- NEUTRON FILES
 
 # Get a list of all ACE files
-neutron_files = release_details[args.release]['neutron_files']
+neutron_files = ace_files_dir.glob(release_details[args.release]['neutron_files'])
 
 # Create output directory if it doesn't exist
 args.destination.mkdir(parents=True, exist_ok=True)

--- a/tests/tests_urls.py
+++ b/tests/tests_urls.py
@@ -1,0 +1,16 @@
+
+import requests
+
+from urls import all_release_details
+
+
+def test_fendl_urls():
+    print(all_release_details)
+
+    for release, value in all_release_details['tendl'].items():
+
+        for file in value['compressed_files']:
+            url = value['base_url'] + file
+
+            responce = requests.get(url, stream=True)
+            assert responce.status_code == 200

--- a/tests/tests_urls.py
+++ b/tests/tests_urls.py
@@ -4,7 +4,7 @@ import requests
 from urls import all_release_details
 
 
-def test_fendl_urls():
+def test_tendl_urls():
     print(all_release_details)
 
     for release, value in all_release_details['tendl'].items():

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,0 +1,38 @@
+
+
+all_release_details = {
+    'tendl': {
+            '2015': {
+                'base_url': 'https://tendl.web.psi.ch/tendl_2015/tar_files/',
+                'compressed_files': ['ACE-n.tgz'],
+                'neutron_files': 'neutron_file/*/*/lib/endf/*-n.ace',
+                'metastables': 'neutron_file/*/*/lib/endf/*m-n.ace',
+                'compressed_file_size': '5.1 GB',
+                'uncompressed_file_size': '40 GB'
+            },
+            '2017': {
+                'base_url': 'https://tendl.web.psi.ch/tendl_2017/tar_files/',
+                'compressed_files': ['tendl17c.tar.bz2'],
+                'neutron_files': 'ace-17/*',
+                'metastables': 'ace-17/*m',
+                'compressed_file_size': '2.1 GB',
+                'uncompressed_file_size': '14 GB'
+            },
+            '2019': {
+                'base_url': 'https://tendl.web.psi.ch/tendl_2019/tar_files/',
+                'compressed_files': ['tendl19c.tar.bz2'],
+                'neutron_files': 'tendl19c/*',
+                'metastables': 'tendl19c/*m',
+                'compressed_file_size': '2.3 GB',
+                'uncompressed_file_size': '10.1 GB'
+            },
+            '2021': {
+                'base_url': 'https://tendl.web.psi.ch/tendl_2021/tar_files/',
+                'compressed_files': ['tendl21c.tar.bz2'],
+                'neutron_files': 'tendl21c/*',
+                'metastables': 'tendl21c/*m',
+                'compressed_file_size': '2.2 GB',
+                'uncompressed_file_size': '10.5 GB'
+            }
+        }
+}


### PR DESCRIPTION
This PR is just an idea for CI that could check that the urls we are downloading from still exist.

It makes use of the standard json data that I've been trying to roll out across the download scripts.

The tests/test_urls.py can be run with pytest that could become part of the CI

This doesn't download the large compressed files, it just checks that they exist.

If there is interest then this could be developed to test a few more scripts and I can add the CI github action files needed.

@AnderGray feedback welcome