### PR TITLE
[WIP] Quick Fix for apple M1 processor

### DIFF
--- a/generate_endf.py
+++ b/generate_endf.py
@@ -11,6 +11,7 @@ import argparse
 import sys
 import tarfile
 import zipfile
+import multiprocessing as mp
 from multiprocessing import Pool
 from pathlib import Path
 from shutil import rmtree, copy, copyfileobj
@@ -298,6 +299,7 @@ for particle in args.particles:
     particle_destination.mkdir(parents=True, exist_ok=True)
 
 library = openmc.data.DataLibrary()
+mp.set_start_method('fork')
 
 if 'neutron' in args.particles:
     particle = 'neutron'


### PR DESCRIPTION
Here is a quick fix to resole some issue with multiprocessing/pool on a apple M1

when running `generate_endl.py` on macOS with an apple M1 proc, the observed issue is:
```
RuntimeError:
        An attempt has been made to start a new process before the
        current process has finished its bootstrapping phase.

        This probably means that you are not using fork to start your
        child processes and you have forgotten to use the proper idiom
        in the main module:

            if __name__ == '__main__':
                freeze_support()
                ...

        The "freeze_support()" line can be omitted if the program
        is not going to be frozen to produce an executable.
```

the implemented fix allows generate_endf.py to move on...
Was not able to test it further yet as I don't have `njoy`yet...

Will pursuit this in the future if this is a proper way to deal with this.



Source to get to the solution:
https://stackoverflow.com/questions/67999589/multiprocessing-with-pool-throws-error-on-m1-macbook
and
https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods


If I understand correctly the problem comes with the default option being `spwan` on macOS but seem not the be working...


I believe this issue should occur when running any script using `multiproccesing.Pool`


**this is far to be completed, but want to post it in case other are experiencing the same issue :)**
