### PR TITLE
processing all reactions for ENDF 7.1 chain file

### DIFF
--- a/depletion/generate_endf71_chain.py
+++ b/depletion/generate_endf71_chain.py
@@ -31,7 +31,7 @@ def main():
 
     decay_files = list((endf_dir / "decay").glob("*endf"))
     neutron_files = list((endf_dir / "neutrons").glob("*endf"))
-    nfy_files = list((endf_dir / "nfy").glob("*endf"))
+    fpy_files = list((endf_dir / "nfy").glob("*endf"))
 
     # Remove erroneous Be7 evaluation that can cause problems
     decay_files.remove(endf_dir / "decay" / "dec-004_Be_007.endf")
@@ -39,11 +39,16 @@ def main():
 
     # check files exist
     for flist, ftype in [(decay_files, "decay"), (neutron_files, "neutron"),
-                         (nfy_files, "neutron fission product yield")]:
+                         (fpy_files, "neutron fission product yield")]:
         if not flist:
             raise IOError("No {} endf files found in {}".format(ftype, endf_dir))
 
-    chain = openmc.deplete.Chain.from_endf(decay_files, nfy_files, neutron_files)
+    chain = openmc.deplete.Chain.from_endf(
+        decay_files=decay_files,
+        fpy_files=fpy_files,
+        neutron_files=neutron_files,
+        reactions=list(openmc.deplete.chain.REACTIONS.keys())
+    )
     chain.export_to_xml('chain_endfb71.xml')
 
 


### PR DESCRIPTION
as mentioned in issue #83 it is perhaps best to include all the reactions in the chain files

This PR adds a arguments to the processing script when it calls ```chain.from_endf``` so that all the reactions are included in the chain file

I am going to implement these changes over [on my fork that has evolved into a package :smile: ](https://github.com/openmc-data-storage/openmc_data) as well but wanted to help keep this repo up to date