### PR TITLE
Allow temperatures to be set in generate_jendl.py

### DIFF
--- a/generate_jendl.py
+++ b/generate_jendl.py
@@ -51,6 +51,9 @@ def main():
     parser.add_argument('--no-cleanup', dest='cleanup', action='store_false',
                         help="Do not remove download directories when data has "
                         "been processed")
+    parser.add_argument('--temperatures', type=float,
+                        default=[250.0, 293.6, 600.0, 900.0, 1200.0, 2500.0],
+                        help="Temperatures in Kelvin", nargs='+')
     parser.set_defaults(download=True, extract=True, cleanup=False)
     args = parser.parse_args()
 
@@ -142,11 +145,10 @@ def main():
 
     library = openmc.data.DataLibrary()
 
-
     with Pool() as pool:
         results = []
         for filename in sorted(neutron_files):
-            func_args = (filename, args.destination, args.libver)
+            func_args = (filename, args.destination, args.libver, args.temperatures)
             r = pool.apply_async(process_neutron, func_args)
             results.append(r)
 


### PR DESCRIPTION
A user recently [pointed out](https://openmc.discourse.group/t/how-to-get-the-jendl5-hdf5-crosssection-library-for-multiple-temperature/3318) that our generate_jendl.py script only generates data at a single temperature. This PR adds the ability to generate data at multiple temperatures.